### PR TITLE
Migrate to use AsyncHTTPClient

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -23,6 +23,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "4.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
         .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.9.0"),
     ],
     targets: [
@@ -34,6 +35,8 @@ let package = Package(
                 .product(name: "SwiftASN1", package: "swift-asn1"),
                 .product(name: "JWTKit", package: "jwt-kit"),
                 .product(name: "AsyncHTTPClient", package: "async-http-client"),
+                .product(name: "NIOFoundationCompat", package: "swift-nio"),
+                .product(name: "NIOHTTP1", package: "swift-nio"),
             ]),
         .testTarget(
             name: "AppStoreServerLibraryTests",

--- a/Package.swift
+++ b/Package.swift
@@ -22,7 +22,8 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-asn1.git", .upToNextMinor(from: "0.8.0")),
         .package(url: "https://github.com/apple/swift-crypto.git", "1.0.0" ..< "3.0.0"),
         .package(url: "https://github.com/vapor/jwt-kit.git", from: "4.0.0"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0")
+        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        .package(url: "https://github.com/swift-server/async-http-client.git", from: "1.9.0"),
     ],
     targets: [
         .target(
@@ -31,7 +32,8 @@ let package = Package(
                 .product(name: "X509", package: "swift-certificates"),
                 .product(name: "Crypto", package: "swift-crypto"),
                 .product(name: "SwiftASN1", package: "swift-asn1"),
-                .product(name: "JWTKit", package: "jwt-kit")
+                .product(name: "JWTKit", package: "jwt-kit"),
+                .product(name: "AsyncHTTPClient", package: "async-http-client"),
             ]),
         .testTarget(
             name: "AppStoreServerLibraryTests",

--- a/Sources/AppStoreServerLibrary/AppStoreServerAPIClient.swift
+++ b/Sources/AppStoreServerLibrary/AppStoreServerAPIClient.swift
@@ -5,6 +5,7 @@ import Crypto
 import JWTKit
 import AsyncHTTPClient
 import NIOHTTP1
+import NIOFoundationCompat
 
 public class AppStoreServerAPIClient {
     

--- a/Sources/AppStoreServerLibrary/AppStoreServerAPIClient.swift
+++ b/Sources/AppStoreServerLibrary/AppStoreServerAPIClient.swift
@@ -3,9 +3,7 @@
 import Foundation
 import Crypto
 import JWTKit
-#if canImport(FoundationNetworking)
-import FoundationNetworking
-#endif
+import AsyncHTTPClient
 
 public class AppStoreServerAPIClient {
     
@@ -19,6 +17,7 @@ public class AppStoreServerAPIClient {
     private let issuerId: String
     private let bundleId: String
     private let url: String
+    private let client: HTTPClient
     ///Create an App Store Server API client
     ///
     ///- Parameter signingKey: Your private key downloaded from App Store Connect
@@ -31,6 +30,11 @@ public class AppStoreServerAPIClient {
         self.issuerId = issuerId
         self.bundleId = bundleId
         self.url = environment == Environment.production ? AppStoreServerAPIClient.productionUrl : AppStoreServerAPIClient.sandboxUrl
+        self.client = .init()
+    }
+    
+    deinit {
+        try? self.client.syncShutdown()
     }
     
     private func makeRequest<T: Encodable>(path: String, method: String, queryParameters: [String: [String]], body: T?) async -> APIResult<Foundation.Data> {

--- a/Sources/AppStoreServerLibrary/ChainVerifier.swift
+++ b/Sources/AppStoreServerLibrary/ChainVerifier.swift
@@ -161,7 +161,7 @@ final class Requester: OCSPRequester {
             let response = try await httpClient.execute(urlRequest, timeout: .seconds(30))
             var body = try await response.body.collect(upTo: 1024 * 1024)
             guard let data = body.readData(length: body.readableBytes) else {
-                return .nonTerminalError(OCSPFetchError())
+                throw OCSPFetchError()
             }
             return .response([UInt8](data))
         } catch {

--- a/Sources/AppStoreServerLibrary/ChainVerifier.swift
+++ b/Sources/AppStoreServerLibrary/ChainVerifier.swift
@@ -6,6 +6,7 @@ import SwiftASN1
 import JWTKit
 import Crypto
 import AsyncHTTPClient
+import NIOFoundationCompat
 
 struct ChainVerifier {
     

--- a/Sources/AppStoreServerLibrary/ChainVerifier.swift
+++ b/Sources/AppStoreServerLibrary/ChainVerifier.swift
@@ -5,9 +5,7 @@ import X509
 import SwiftASN1
 import JWTKit
 import Crypto
-#if canImport(FoundationNetworking)
-import FoundationNetworking
-#endif
+import AsyncHTTPClient
 
 struct ChainVerifier {
     
@@ -19,7 +17,7 @@ struct ChainVerifier {
     
     init(rootCertificates: [Foundation.Data]) throws {
         let parsedCertificates = try rootCertificates.map { try Certificate(derEncoded: [UInt8]($0)) }
-        store = CertificateStore(parsedCertificates)
+        self.store = CertificateStore(parsedCertificates)
     }
     
     func verify<T: DecodedSignedData>(signedData: String, type: T.Type, onlineVerification: Bool) async -> VerificationResult<T> where T: Decodable {
@@ -151,27 +149,19 @@ final class AppStoreOIDPolicy: VerifierPolicy {
 
 final class Requester: OCSPRequester {
     func query(request: [UInt8], uri: String) async throws -> [UInt8] {
-        let url = URL(string: uri)!
-        var urlRequest = URLRequest(url: url)
-        urlRequest.httpMethod = "POST"
-        urlRequest.setValue("application/ocsp-request", forHTTPHeaderField: "Content-Type")
-        urlRequest.httpBody = Foundation.Data(request)
-        
-        let data: Foundation.Data = try await withCheckedThrowingContinuation() { c in
-            let urlSessionDataTask = URLSession.shared.dataTask(with: urlRequest) {data, response, error in
-                if let e = error {
-                    c.resume(throwing: e)
-                    return
-                }
-                guard let unwrappedData = data else {
-                    c.resume(throwing: OCSPFetchError())
-                    return
-                }
-                c.resume(returning: unwrappedData)
-            }
-            urlSessionDataTask.resume()
+        let httpClient = HTTPClient()
+        defer {
+            try? httpClient.syncShutdown()
         }
-        
+        var urlRequest = HTTPClientRequest(url: uri)
+        urlRequest.method = .POST
+        urlRequest.headers.add(name: "Content-Type", value: "application/ocsp-request")
+        urlRequest.body = .bytes(request)
+        let response = try await httpClient.execute(urlRequest, timeout: .seconds(30))
+        var body = try await response.body.collect(upTo: 1024 * 1024)
+        guard let data = body.readData(length: body.readableBytes) else {
+            throw OCSPFetchError()
+        }
         return [UInt8](data)
     }
     

--- a/Sources/AppStoreServerLibrary/SignedDataVerifier.swift
+++ b/Sources/AppStoreServerLibrary/SignedDataVerifier.swift
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Apple Inc. Licensed under MIT License.
 
 import Foundation
+
 ///A verifier and decoder class designed to decode signed data from the App Store.
 public struct SignedDataVerifier {
     


### PR DESCRIPTION
URLSession is broken, incomplete and generally just a mess on Linux. For server-side applications to recommendation is to use [AsyncHTTPClient](https://github.com/swift-server/async-http-client). This PR migrates from `URLSession` to use AsyncHTTPClient instead.

Resolves #4 