### PR TITLE
Throwing a configuration error in the constructor if appAppleId is null/nil/undefined and the environment is Production

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ import AppStoreServerLibrary
 
 let bundleId = "com.example"
 let appleRootCAs = loadRootCAs() // Specific implementation may vary
+let appAppleId: String? = nil // For production environments, it's required
 let enableOnlineChecks = true
 let environment = Environment.sandbox
 
 // try! used for example purposes only
-let verifier = try! SignedDataVerifier(rootCertificates: appleRootCAs, bundleId: bundleId, appAppleId: nil, environment: environment, enableOnlineChecks: enableOnlineChecks)
+let verifier = try! SignedDataVerifier(rootCertificates: appleRootCAs, bundleId: bundleId, appAppleId: appAppleId, environment: environment, enableOnlineChecks: enableOnlineChecks)
 
 let notificationPayload = "ey..."
 let notificationResult = await verifier.verifyAndDecodeNotification(signedPayload: notificationPayload)

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ import AppStoreServerLibrary
 
 let bundleId = "com.example"
 let appleRootCAs = loadRootCAs() // Specific implementation may vary
-let appAppleId: String? = nil // For production environments, it's required
+let appAppleId: Int64? = nil // appAppleId must be provided for the Production environment
 let enableOnlineChecks = true
 let environment = Environment.sandbox
 

--- a/Sources/AppStoreServerLibrary/SignedDataVerifier.swift
+++ b/Sources/AppStoreServerLibrary/SignedDataVerifier.swift
@@ -4,7 +4,11 @@ import Foundation
 
 ///A verifier and decoder class designed to decode signed data from the App Store.
 public struct SignedDataVerifier {
-    
+
+    public enum ConfigurationError: Error {
+        case INVALID_APP_APPLE_ID
+    }
+
     private var bundleId: String
     private var appAppleId: Int64?
     private var environment: Environment
@@ -18,6 +22,11 @@ public struct SignedDataVerifier {
     /// - Parameter enableOnlineChecks: Whether to enable revocation checking and check expiration using the current date
     /// - Throws: When the root certificates are malformed
     public init(rootCertificates: [Foundation.Data], bundleId: String, appAppleId: Int64?, environment: Environment, enableOnlineChecks: Bool) throws {
+
+        guard !(environment == .production && appAppleId == nil) else {
+            throw ConfigurationError.INVALID_APP_APPLE_ID
+        }
+
         self.bundleId = bundleId
         self.appAppleId = appAppleId
         self.environment = environment


### PR DESCRIPTION
- #34 

## WHAT

- Throw configuration error if appAppleId is nil and the environment is Production.
- Add a comment stating that it is required for Production.