### PR TITLE
Conform data models to Sendable

### DIFF
--- a/Sources/AppStoreServerLibrary/Models/AccountTenure.swift
+++ b/Sources/AppStoreServerLibrary/Models/AccountTenure.swift
@@ -3,7 +3,7 @@
 ///The age of the customer’s account.
 ///
 ///[accountTenure](https://developer.apple.com/documentation/appstoreserverapi/accounttenure)
-public enum AccountTenure: Int32, Decodable, Encodable, Hashable {
+public enum AccountTenure: Int32, Decodable, Encodable, Hashable, Sendable {
     case undeclared = 0
     case zeroToThreeDays = 1
     case threeDaysToTenDays = 2

--- a/Sources/AppStoreServerLibrary/Models/AppTransaction.swift
+++ b/Sources/AppStoreServerLibrary/Models/AppTransaction.swift
@@ -6,7 +6,7 @@ import Foundation
 ///Information that represents the customer’s purchase of the app, cryptographically signed by the App Store.
 ///
 ///[AppTransaction](https://developer.apple.com/documentation/storekit/apptransaction)
-public struct AppTransaction: DecodedSignedData, Decodable, Encodable, Hashable {
+public struct AppTransaction: DecodedSignedData, Decodable, Encodable, Hashable, Sendable {
     
     public init(receiptType: Environment? = nil, appAppleId: Int64? = nil, bundleId: String? = nil, applicationVersion: String? = nil, versionExternalIdentifier: Int64? = nil, receiptCreationDate: Date? = nil, originalPurchaseDate: Date? = nil, originalApplicationVersion: String? = nil, deviceVerification: String? = nil, deviceVerificationNonce: UUID? = nil, preorderDate: Date? = nil) {
         self.receiptType = receiptType

--- a/Sources/AppStoreServerLibrary/Models/AutoRenewStatus.swift
+++ b/Sources/AppStoreServerLibrary/Models/AutoRenewStatus.swift
@@ -3,7 +3,7 @@
 ///The renewal status for an auto-renewable subscription.
 ///
 ///[autoRenewStatus](https://developer.apple.com/documentation/appstoreserverapi/autorenewstatus)
-public enum AutoRenewStatus: Int32, Decodable, Encodable, Hashable {
+public enum AutoRenewStatus: Int32, Decodable, Encodable, Hashable, Sendable {
     case off = 0
     case on = 1
 }

--- a/Sources/AppStoreServerLibrary/Models/CheckTestNotificationResponse.swift
+++ b/Sources/AppStoreServerLibrary/Models/CheckTestNotificationResponse.swift
@@ -3,7 +3,7 @@
 ///A response that contains the contents of the test notification sent by the App Store server and the result from your server.
 ///
 ///[CheckTestNotificationResponse](https://developer.apple.com/documentation/appstoreserverapi/checktestnotificationresponse)
-public struct CheckTestNotificationResponse: Decodable, Encodable, Hashable {
+public struct CheckTestNotificationResponse: Decodable, Encodable, Hashable, Sendable {
 
     public init(signedPayload: String? = nil, sendAttempts: [SendAttemptItem]? = nil) {
         self.signedPayload = signedPayload

--- a/Sources/AppStoreServerLibrary/Models/ConsumptionRequest.swift
+++ b/Sources/AppStoreServerLibrary/Models/ConsumptionRequest.swift
@@ -5,7 +5,7 @@ import Foundation
 ///The request body containing consumption information.
 ///
 ///[ConsumptionRequest](https://developer.apple.com/documentation/appstoreserverapi/consumptionrequest)
-public struct ConsumptionRequest: Decodable, Encodable, Hashable {
+public struct ConsumptionRequest: Decodable, Encodable, Hashable, Sendable {
     
     public init(customerConsented: Bool? = nil, consumptionStatus: ConsumptionStatus? = nil, platform: Platform? = nil, sampleContentProvided: Bool? = nil, deliveryStatus: DeliveryStatus? = nil, appAccountToken: UUID? = nil, accountTenure: AccountTenure? = nil, playTime: PlayTime? = nil, lifetimeDollarsRefunded: LifetimeDollarsRefunded? = nil, lifetimeDollarsPurchased: LifetimeDollarsPurchased? = nil, userStatus: UserStatus? = nil, refundPreference: RefundPreference? = nil) {
         self.customerConsented = customerConsented

--- a/Sources/AppStoreServerLibrary/Models/ConsumptionRequestReason.swift
+++ b/Sources/AppStoreServerLibrary/Models/ConsumptionRequestReason.swift
@@ -3,7 +3,7 @@
 ///The customer-provided reason for a refund request.
 ///
 ///[consumptionRequestReason](https://developer.apple.com/documentation/appstoreservernotifications/consumptionrequestreason)
-public enum ConsumptionRequestReason: String, Decodable, Encodable, Hashable {
+public enum ConsumptionRequestReason: String, Decodable, Encodable, Hashable, Sendable {
     case unintendedPurchase = "UNINTENDED_PURCHASE"
     case fulfillmentIssue = "FULFILLMENT_ISSUE"
     case unsatisfiedWithPurchase = "UNSATISFIED_WITH_PURCHASE"

--- a/Sources/AppStoreServerLibrary/Models/ConsumptionStatus.swift
+++ b/Sources/AppStoreServerLibrary/Models/ConsumptionStatus.swift
@@ -3,7 +3,7 @@
 ///A value that indicates the extent to which the customer consumed the in-app purchase.
 ///
 ///[consumptionStatus](https://developer.apple.com/documentation/appstoreserverapi/consumptionstatus)
-public enum ConsumptionStatus: Int32, Decodable, Encodable, Hashable {
+public enum ConsumptionStatus: Int32, Decodable, Encodable, Hashable, Sendable {
     case undeclared = 0
     case notConsumed = 1
     case partiallyConsumed = 2

--- a/Sources/AppStoreServerLibrary/Models/Data.swift
+++ b/Sources/AppStoreServerLibrary/Models/Data.swift
@@ -3,7 +3,7 @@
 ///The app metadata and the signed renewal and transaction information.
 ///
 ///[data](https://developer.apple.com/documentation/appstoreservernotifications/data)
-public struct Data: Decodable, Encodable, Hashable {
+public struct Data: Decodable, Encodable, Hashable, Sendable {
     
     public init(environment: Environment? = nil, appAppleId: Int64? = nil, bundleId: String? = nil, bundleVersion: String? = nil, signedTransactionInfo: String? = nil, signedRenewalInfo: String? = nil, status: Status? = nil, consumptionRequestReason: ConsumptionRequestReason? = nil) {
         self.environment = environment

--- a/Sources/AppStoreServerLibrary/Models/DeliveryStatus.swift
+++ b/Sources/AppStoreServerLibrary/Models/DeliveryStatus.swift
@@ -3,7 +3,7 @@
 ///A value that indicates whether the app successfully delivered an in-app purchase that works properly.
 ///
 ///[deliveryStatus](https://developer.apple.com/documentation/appstoreserverapi/deliverystatus)
-public enum DeliveryStatus: Int32, Decodable, Encodable, Hashable {
+public enum DeliveryStatus: Int32, Decodable, Encodable, Hashable, Sendable {
     case deliveredAndWorkingProperly = 0
     case didNotDeliverDueToQualityIssue = 1
     case deliveredWrongItem = 2

--- a/Sources/AppStoreServerLibrary/Models/Environment.swift
+++ b/Sources/AppStoreServerLibrary/Models/Environment.swift
@@ -3,7 +3,7 @@
 ///The server environment, either sandbox or production.
 ///
 ///[environment](https://developer.apple.com/documentation/appstoreserverapi/environment)
-public enum Environment: String, Decodable, Encodable, Hashable {
+public enum Environment: String, Decodable, Encodable, Hashable, Sendable {
     case sandbox = "Sandbox"
     case production = "Production"
     case xcode = "Xcode"

--- a/Sources/AppStoreServerLibrary/Models/ErrorPayload.swift
+++ b/Sources/AppStoreServerLibrary/Models/ErrorPayload.swift
@@ -1,7 +1,7 @@
 // Copyright (c) 2023 Apple Inc. Licensed under MIT License.
 
 
-public struct ErrorPayload: Decodable, Encodable, Hashable {
+public struct ErrorPayload: Decodable, Encodable, Hashable, Sendable {
     public var errorCode: Int64?
     public var errorMessage: String?
 }

--- a/Sources/AppStoreServerLibrary/Models/ExpirationIntent.swift
+++ b/Sources/AppStoreServerLibrary/Models/ExpirationIntent.swift
@@ -3,7 +3,7 @@
 ///The reason an auto-renewable subscription expired.
 ///
 ///[expirationIntent](https://developer.apple.com/documentation/appstoreserverapi/expirationintent)
-public enum ExpirationIntent: Int32, Decodable, Encodable, Hashable {
+public enum ExpirationIntent: Int32, Decodable, Encodable, Hashable, Sendable {
     case customerCancelled = 1
     case billingError = 2
     case customerDidNotConsentToPriceIncrease = 3

--- a/Sources/AppStoreServerLibrary/Models/ExtendReasonCode.swift
+++ b/Sources/AppStoreServerLibrary/Models/ExtendReasonCode.swift
@@ -3,7 +3,7 @@
 ///The code that represents the reason for the subscription-renewal-date extension.
 ///
 ///[extendReasonCode](https://developer.apple.com/documentation/appstoreserverapi/extendreasoncode)
-public enum ExtendReasonCode: Int32, Decodable, Encodable, Hashable {
+public enum ExtendReasonCode: Int32, Decodable, Encodable, Hashable, Sendable {
     case undeclared = 0
     case customerSatisfaction = 1
     case other = 2

--- a/Sources/AppStoreServerLibrary/Models/ExtendRenewalDateRequest.swift
+++ b/Sources/AppStoreServerLibrary/Models/ExtendRenewalDateRequest.swift
@@ -3,7 +3,7 @@
 ///The request body that contains subscription-renewal-extension data for an individual subscription.
 ///
 ///[ExtendRenewalDateRequest](https://developer.apple.com/documentation/appstoreserverapi/extendrenewaldaterequest)
-public struct ExtendRenewalDateRequest: Decodable, Encodable, Hashable {
+public struct ExtendRenewalDateRequest: Decodable, Encodable, Hashable, Sendable {
     
     public init(extendByDays: Int32? = nil, extendReasonCode: ExtendReasonCode? = nil, requestIdentifier: String? = nil) {
         self.extendByDays = extendByDays

--- a/Sources/AppStoreServerLibrary/Models/ExtendRenewalDateResponse.swift
+++ b/Sources/AppStoreServerLibrary/Models/ExtendRenewalDateResponse.swift
@@ -4,7 +4,7 @@ import Foundation
 ///A response that indicates whether an individual renewal-date extension succeeded, and related details.
 ///
 ///[ExtendRenewalDateResponse](https://developer.apple.com/documentation/appstoreserverapi/extendrenewaldateresponse)
-public struct ExtendRenewalDateResponse: Decodable, Encodable, Hashable {
+public struct ExtendRenewalDateResponse: Decodable, Encodable, Hashable, Sendable {
 
     public init(originalTransactionId: String? = nil, webOrderLineItemId: String? = nil, success: Bool? = nil, effectiveDate: Date? = nil) {
         self.originalTransactionId = originalTransactionId

--- a/Sources/AppStoreServerLibrary/Models/ExternalPurchaseToken.swift
+++ b/Sources/AppStoreServerLibrary/Models/ExternalPurchaseToken.swift
@@ -3,7 +3,7 @@
 ///The payload data that contains an external purchase token.
 ///
 ///[externalPurchaseToken](https://developer.apple.com/documentation/appstoreservernotifications/externalpurchasetoken)
-public struct ExternalPurchaseToken: Decodable, Encodable, Hashable {
+public struct ExternalPurchaseToken: Decodable, Encodable, Hashable, Sendable {
     
     public init(externalPurchaseId: String? = nil, tokenCreationDate: Int64? = nil, appAppleId: Int64? = nil, bundleId: String? = nil) {
         self.externalPurchaseId = externalPurchaseId

--- a/Sources/AppStoreServerLibrary/Models/HistoryResponse.swift
+++ b/Sources/AppStoreServerLibrary/Models/HistoryResponse.swift
@@ -3,7 +3,7 @@
 ///A response that contains the customer’s transaction history for an app.
 ///
 ///[HistoryResponse](https://developer.apple.com/documentation/appstoreserverapi/historyresponse)
-public struct HistoryResponse: Decodable, Encodable, Hashable {
+public struct HistoryResponse: Decodable, Encodable, Hashable, Sendable {
     
     public init(revision: String? = nil, hasMore: Bool? = nil, bundleId: String? = nil, appAppleId: Int64? = nil, environment: Environment? = nil, signedTransactions: [String]? = nil) {
         self.revision = revision

--- a/Sources/AppStoreServerLibrary/Models/InAppOwnershipType.swift
+++ b/Sources/AppStoreServerLibrary/Models/InAppOwnershipType.swift
@@ -3,7 +3,7 @@
 ///The relationship of the user with the family-shared purchase to which they have access.
 ///
 ///[inAppOwnershipType](https://developer.apple.com/documentation/appstoreserverapi/inappownershiptype)
-public enum InAppOwnershipType: String, Decodable, Encodable, Hashable {
+public enum InAppOwnershipType: String, Decodable, Encodable, Hashable, Sendable {
     case familyShared = "FAMILY_SHARED"
     case purchased = "PURCHASED"
 }

--- a/Sources/AppStoreServerLibrary/Models/JWSRenewalInfoDecodedPayload.swift
+++ b/Sources/AppStoreServerLibrary/Models/JWSRenewalInfoDecodedPayload.swift
@@ -4,7 +4,7 @@ import Foundation
 ///A decoded payload containing subscription renewal information for an auto-renewable subscription.
 ///
 ///[JWSRenewalInfoDecodedPayload](https://developer.apple.com/documentation/appstoreserverapi/jwsrenewalinfodecodedpayload)
-public struct JWSRenewalInfoDecodedPayload: DecodedSignedData, Decodable, Encodable, Hashable {
+public struct JWSRenewalInfoDecodedPayload: DecodedSignedData, Decodable, Encodable, Hashable, Sendable {
     
     public init(expirationIntent: ExpirationIntent? = nil, originalTransactionId: String? = nil, autoRenewProductId: String? = nil, productId: String? = nil, autoRenewStatus: AutoRenewStatus? = nil, isInBillingRetryPeriod: Bool? = nil, priceIncreaseStatus: PriceIncreaseStatus? = nil, gracePeriodExpiresDate: Date? = nil, offerType: OfferType? = nil, offerIdentifier: String? = nil, signedDate: Date? = nil, environment: Environment? = nil, recentSubscriptionStartDate: Date? = nil, renewalDate: Date? = nil, currency: String? = nil, renewalPrice: Int64? = nil, offerDiscountType: OfferDiscountType? = nil, eligibleWinBackOfferIds: [String]? = nil) {
         self.expirationIntent = expirationIntent

--- a/Sources/AppStoreServerLibrary/Models/JWSTransactionDecodedPayload.swift
+++ b/Sources/AppStoreServerLibrary/Models/JWSTransactionDecodedPayload.swift
@@ -4,7 +4,7 @@ import Foundation
 ///A decoded payload containing transaction information.
 ///
 ///[JWSTransactionDecodedPayload](https://developer.apple.com/documentation/appstoreserverapi/jwstransactiondecodedpayload)
-public struct JWSTransactionDecodedPayload: DecodedSignedData, Decodable, Encodable, Hashable {
+public struct JWSTransactionDecodedPayload: DecodedSignedData, Decodable, Encodable, Hashable, Sendable {
     
     public init(originalTransactionId: String? = nil, transactionId: String? = nil, webOrderLineItemId: String? = nil, bundleId: String? = nil, productId: String? = nil, subscriptionGroupIdentifier: String? = nil, purchaseDate: Date? = nil, originalPurchaseDate: Date? = nil, expiresDate: Date? = nil, quantity: Int32? = nil, type: ProductType? = nil, appAccountToken: UUID? = nil, inAppOwnershipType: InAppOwnershipType? = nil, signedDate: Date? = nil, revocationReason: RevocationReason? = nil, revocationDate: Date? = nil, isUpgraded: Bool? = nil, offerType: OfferType? = nil, offerIdentifier: String? = nil, environment: Environment? = nil, storefront: String? = nil, storefrontId: String? = nil, transactionReason: TransactionReason? = nil, currency: String? = nil, price: Int64? = nil, offerDiscountType: OfferDiscountType? = nil) {
         self.originalTransactionId = originalTransactionId

--- a/Sources/AppStoreServerLibrary/Models/LastTransactionsItem.swift
+++ b/Sources/AppStoreServerLibrary/Models/LastTransactionsItem.swift
@@ -3,7 +3,7 @@
 ///The most recent App Store-signed transaction information and App Store-signed renewal information for an auto-renewable subscription.
 ///
 ///[lastTransactionsItem](https://developer.apple.com/documentation/appstoreserverapi/lasttransactionsitem)
-public struct LastTransactionsItem: Decodable, Encodable, Hashable {
+public struct LastTransactionsItem: Decodable, Encodable, Hashable, Sendable {
     
     public init(status: Status? = nil, originalTransactionId: String? = nil, signedTransactionInfo: String? = nil, signedRenewalInfo: String? = nil) {
         self.status = status

--- a/Sources/AppStoreServerLibrary/Models/LifetimeDollarsPurchased.swift
+++ b/Sources/AppStoreServerLibrary/Models/LifetimeDollarsPurchased.swift
@@ -3,7 +3,7 @@
 ///A value that indicates the total amount, in USD, of in-app purchases the customer has made in your app, across all platforms.
 ///
 ///[lifetimeDollarsPurchased](https://developer.apple.com/documentation/appstoreserverapi/lifetimedollarspurchased)
-public enum LifetimeDollarsPurchased: Int32, Decodable, Encodable, Hashable {
+public enum LifetimeDollarsPurchased: Int32, Decodable, Encodable, Hashable, Sendable {
     case undeclared = 0
     case zeroDollars = 1
     case oneCentToFortyNineDollarsAndNinetyNineCents = 2

--- a/Sources/AppStoreServerLibrary/Models/LifetimeDollarsRefunded.swift
+++ b/Sources/AppStoreServerLibrary/Models/LifetimeDollarsRefunded.swift
@@ -3,7 +3,7 @@
 ///A value that indicates the dollar amount of refunds the customer has received in your app, since purchasing the app, across all platforms.
 ///
 ///[lifetimeDollarsRefunded](https://developer.apple.com/documentation/appstoreserverapi/lifetimedollarsrefunded)
-public enum LifetimeDollarsRefunded: Int32, Decodable, Encodable, Hashable {
+public enum LifetimeDollarsRefunded: Int32, Decodable, Encodable, Hashable, Sendable {
     case undeclared = 0
     case zeroDollars = 1
     case oneCentToFortyNineDollarsAndNinetyNineCents = 2

--- a/Sources/AppStoreServerLibrary/Models/MassExtendRenewalDateRequest.swift
+++ b/Sources/AppStoreServerLibrary/Models/MassExtendRenewalDateRequest.swift
@@ -3,7 +3,7 @@
 ///The request body that contains subscription-renewal-extension data to apply for all eligible active subscribers.
 ///
 ///[MassExtendRenewalDateRequest](https://developer.apple.com/documentation/appstoreserverapi/massextendrenewaldaterequest)
-public struct MassExtendRenewalDateRequest: Decodable, Encodable, Hashable {
+public struct MassExtendRenewalDateRequest: Decodable, Encodable, Hashable, Sendable {
     
     public init(extendByDays: Int32? = nil, extendReasonCode: ExtendReasonCode? = nil, requestIdentifier: String? = nil, storefrontCountryCodes: [String]? = nil, productId: String? = nil) {
         self.extendByDays = extendByDays

--- a/Sources/AppStoreServerLibrary/Models/MassExtendRenewalDateResponse.swift
+++ b/Sources/AppStoreServerLibrary/Models/MassExtendRenewalDateResponse.swift
@@ -3,7 +3,7 @@
 ///A response that indicates the server successfully received the subscription-renewal-date extension request.
 ///
 ///[MassExtendRenewalDateResponse](https://developer.apple.com/documentation/appstoreserverapi/massextendrenewaldateresponse)
-public struct MassExtendRenewalDateResponse: Decodable, Encodable, Hashable {
+public struct MassExtendRenewalDateResponse: Decodable, Encodable, Hashable, Sendable {
 
     public init(requestIdentifier: String? = nil) {
         self.requestIdentifier = requestIdentifier

--- a/Sources/AppStoreServerLibrary/Models/MassExtendRenewalDateStatusResponse.swift
+++ b/Sources/AppStoreServerLibrary/Models/MassExtendRenewalDateStatusResponse.swift
@@ -4,7 +4,7 @@ import Foundation
 ///A response that indicates the current status of a request to extend the subscription renewal date to all eligible subscribers.
 ///
 ///[MassExtendRenewalDateStatusResponse](https://developer.apple.com/documentation/appstoreserverapi/massextendrenewaldatestatusresponse)
-public struct MassExtendRenewalDateStatusResponse: Decodable, Encodable, Hashable {
+public struct MassExtendRenewalDateStatusResponse: Decodable, Encodable, Hashable, Sendable {
 
     public init(requestIdentifier: String? = nil, complete: Bool? = nil, completeDate: Date? = nil, succeededCount: Int64? = nil, failedCount: Int64? = nil) {
         self.requestIdentifier = requestIdentifier

--- a/Sources/AppStoreServerLibrary/Models/NotificationHistoryRequest.swift
+++ b/Sources/AppStoreServerLibrary/Models/NotificationHistoryRequest.swift
@@ -4,7 +4,7 @@ import Foundation
 ///The request body for notification history.
 ///
 ///[NotificationHistoryRequest](https://developer.apple.com/documentation/appstoreserverapi/notificationhistoryrequest)
-public struct NotificationHistoryRequest: Decodable, Encodable, Hashable {
+public struct NotificationHistoryRequest: Decodable, Encodable, Hashable, Sendable {
 
     public init(startDate: Date? = nil, endDate: Date? = nil, notificationType: NotificationTypeV2? = nil, notificationSubtype: Subtype? = nil, transactionId: String? = nil, onlyFailures: Bool? = nil) {
         self.startDate = startDate

--- a/Sources/AppStoreServerLibrary/Models/NotificationHistoryResponse.swift
+++ b/Sources/AppStoreServerLibrary/Models/NotificationHistoryResponse.swift
@@ -3,7 +3,7 @@
 ///A response that contains the App Store Server Notifications history for your app.
 ///
 ///[NotificationHistoryResponse](https://developer.apple.com/documentation/appstoreserverapi/notificationhistoryresponse)
-public struct NotificationHistoryResponse: Decodable, Encodable, Hashable {
+public struct NotificationHistoryResponse: Decodable, Encodable, Hashable, Sendable {
 
     public init(paginationToken: String? = nil, hasMore: Bool? = nil, notificationHistory: [NotificationHistoryResponseItem]? = nil) {
         self.paginationToken = paginationToken

--- a/Sources/AppStoreServerLibrary/Models/NotificationHistoryResponseItem.swift
+++ b/Sources/AppStoreServerLibrary/Models/NotificationHistoryResponseItem.swift
@@ -3,7 +3,7 @@
 ///The App Store server notification history record, including the signed notification payload and the result of the server’s first send attempt.
 ///
 ///[notificationHistoryResponseItem](https://developer.apple.com/documentation/appstoreserverapi/notificationhistoryresponseitem)
-public struct NotificationHistoryResponseItem: Decodable, Encodable, Hashable {
+public struct NotificationHistoryResponseItem: Decodable, Encodable, Hashable, Sendable {
 
     public init(signedPayload: String? = nil, sendAttempts: [SendAttemptItem]? = nil) {
         self.signedPayload = signedPayload

--- a/Sources/AppStoreServerLibrary/Models/NotificationTypeV2.swift
+++ b/Sources/AppStoreServerLibrary/Models/NotificationTypeV2.swift
@@ -3,7 +3,7 @@
 ///The type that describes the in-app purchase or external purchase event for which the App Store sends the version 2 notification.
 ///
 ///[notificationType](https://developer.apple.com/documentation/appstoreservernotifications/notificationtype)
-public enum NotificationTypeV2: String, Decodable, Encodable, Hashable {
+public enum NotificationTypeV2: String, Decodable, Encodable, Hashable, Sendable {
     case subscribed = "SUBSCRIBED"
     case didChangeRenewalPref = "DID_CHANGE_RENEWAL_PREF"
     case didChangeRenewalStatus = "DID_CHANGE_RENEWAL_STATUS"

--- a/Sources/AppStoreServerLibrary/Models/OfferDiscountType.swift
+++ b/Sources/AppStoreServerLibrary/Models/OfferDiscountType.swift
@@ -3,7 +3,7 @@
 ///The payment mode you configure for an introductory offer, promotional offer, or offer code on an auto-renewable subscription.
 ///
 ///[offerDiscountType](https://developer.apple.com/documentation/appstoreserverapi/offerdiscounttype)
-public enum OfferDiscountType: String, Decodable, Encodable, Hashable {
+public enum OfferDiscountType: String, Decodable, Encodable, Hashable, Sendable {
     case freeTrial = "FREE_TRIAL"
     case payAsYouGo = "PAY_AS_YOU_GO"
     case payUpFront = "PAY_UP_FRONT"

--- a/Sources/AppStoreServerLibrary/Models/OfferType.swift
+++ b/Sources/AppStoreServerLibrary/Models/OfferType.swift
@@ -3,7 +3,7 @@
 ///The type of subscription offer.
 ///
 ///[offerType](https://developer.apple.com/documentation/appstoreserverapi/offertype)
-public enum OfferType: Int32, Decodable, Encodable, Hashable {
+public enum OfferType: Int32, Decodable, Encodable, Hashable, Sendable {
     case introductoryOffer = 1
     case promotionalOffer = 2
     case subscriptionOfferCode = 3

--- a/Sources/AppStoreServerLibrary/Models/OrderLookupResponse.swift
+++ b/Sources/AppStoreServerLibrary/Models/OrderLookupResponse.swift
@@ -3,7 +3,7 @@
 ///A response that includes the order lookup status and an array of signed transactions for the in-app purchases in the order.
 ///
 ///[OrderLookupResponse](https://developer.apple.com/documentation/appstoreserverapi/orderlookupresponse)
-public struct OrderLookupResponse: Decodable, Encodable, Hashable {
+public struct OrderLookupResponse: Decodable, Encodable, Hashable, Sendable {
     
     public init(status: OrderLookupStatus? = nil, signedTransactions: [String]? = nil) {
         self.status = status

--- a/Sources/AppStoreServerLibrary/Models/OrderLookupStatus.swift
+++ b/Sources/AppStoreServerLibrary/Models/OrderLookupStatus.swift
@@ -3,7 +3,7 @@
 ///A value that indicates whether the order ID in the request is valid for your app.
 ///
 ///[OrderLookupStatus](https://developer.apple.com/documentation/appstoreserverapi/orderlookupstatus)
-public enum OrderLookupStatus: Int32, Decodable, Encodable, Hashable {
+public enum OrderLookupStatus: Int32, Decodable, Encodable, Hashable, Sendable {
     case valid = 0
     case invalid = 1
 }

--- a/Sources/AppStoreServerLibrary/Models/Platform.swift
+++ b/Sources/AppStoreServerLibrary/Models/Platform.swift
@@ -3,7 +3,7 @@
 ///The platform on which the customer consumed the in-app purchase.
 ///
 ///[platform](https://developer.apple.com/documentation/appstoreserverapi/platform)
-public enum Platform: Int32, Decodable, Encodable, Hashable {
+public enum Platform: Int32, Decodable, Encodable, Hashable, Sendable {
     case undeclared = 0
     case apple = 1
     case nonApple = 2

--- a/Sources/AppStoreServerLibrary/Models/PlayTime.swift
+++ b/Sources/AppStoreServerLibrary/Models/PlayTime.swift
@@ -3,7 +3,7 @@
 ///A value that indicates the amount of time that the customer used the app.
 ///
 ///[playTime](https://developer.apple.com/documentation/appstoreserverapi/playtime)
-public enum PlayTime: Int32, Decodable, Encodable, Hashable {
+public enum PlayTime: Int32, Decodable, Encodable, Hashable, Sendable {
     case undeclared = 0
     case zeroToFiveMinutes = 1
     case fiveToSixtyMinutes = 2

--- a/Sources/AppStoreServerLibrary/Models/PriceIncreaseStatus.swift
+++ b/Sources/AppStoreServerLibrary/Models/PriceIncreaseStatus.swift
@@ -3,7 +3,7 @@
 ///The status that indicates whether an auto-renewable subscription is subject to a price increase.
 ///
 ///[priceIncreaseStatus](https://developer.apple.com/documentation/appstoreserverapi/priceincreasestatus)
-public enum PriceIncreaseStatus: Int32, Decodable, Encodable, Hashable {
+public enum PriceIncreaseStatus: Int32, Decodable, Encodable, Hashable, Sendable {
     case customerHasNotResponded = 0
     case customerConsentedOrWasNotifiedWithoutNeedingConsent = 1
 }

--- a/Sources/AppStoreServerLibrary/Models/ProductType.swift
+++ b/Sources/AppStoreServerLibrary/Models/ProductType.swift
@@ -3,7 +3,7 @@
 ///The type of in-app purchase products you can offer in your app.
 ///
 ///[type](https://developer.apple.com/documentation/appstoreserverapi/type)
-public enum ProductType: String, Decodable, Encodable, Hashable {
+public enum ProductType: String, Decodable, Encodable, Hashable, Sendable {
     case autoRenewableSubscription = "Auto-Renewable Subscription"
     case nonConsumable = "Non-Consumable"
     case consumable = "Consumable"

--- a/Sources/AppStoreServerLibrary/Models/RefundHistoryResponse.swift
+++ b/Sources/AppStoreServerLibrary/Models/RefundHistoryResponse.swift
@@ -3,7 +3,7 @@
 ///A response that contains an array of signed JSON Web Signature (JWS) refunded transactions, and paging information.
 ///
 ///[RefundHistoryResponse](https://developer.apple.com/documentation/appstoreserverapi/refundhistoryresponse)
-public struct RefundHistoryResponse: Decodable, Encodable, Hashable {
+public struct RefundHistoryResponse: Decodable, Encodable, Hashable, Sendable {
 
     public init(signedTransactions: [String]? = nil, revision: String? = nil, hasMore: Bool? = nil) {
         self.signedTransactions = signedTransactions

--- a/Sources/AppStoreServerLibrary/Models/RefundPreference.swift
+++ b/Sources/AppStoreServerLibrary/Models/RefundPreference.swift
@@ -3,7 +3,7 @@
 ///A value that indicates your preferred outcome for the refund request.
 ///
 ///[refundPreference](https://developer.apple.com/documentation/appstoreserverapi/refundpreference)
-public enum RefundPreference: Int32, Decodable, Encodable, Hashable {
+public enum RefundPreference: Int32, Decodable, Encodable, Hashable, Sendable {
     case undeclared = 0
     case preferGrant = 1
     case preferDecline = 2

--- a/Sources/AppStoreServerLibrary/Models/ResponseBodyV2.swift
+++ b/Sources/AppStoreServerLibrary/Models/ResponseBodyV2.swift
@@ -3,7 +3,7 @@
 ///The response body the App Store sends in a version 2 server notification.
 ///
 ///[responseBodyV2](https://developer.apple.com/documentation/appstoreservernotifications/responsebodyv2)
-public struct ResponseBodyV2: Decodable, Encodable, Hashable {
+public struct ResponseBodyV2: Decodable, Encodable, Hashable, Sendable {
 
     public init(signedPayload: String? = nil) {
         self.signedPayload = signedPayload

--- a/Sources/AppStoreServerLibrary/Models/ResponseBodyV2DecodedPayload.swift
+++ b/Sources/AppStoreServerLibrary/Models/ResponseBodyV2DecodedPayload.swift
@@ -4,8 +4,8 @@ import Foundation
 ///A decoded payload containing the version 2 notification data.
 ///
 ///[responseBodyV2DecodedPayload](https://developer.apple.com/documentation/appstoreservernotifications/responsebodyv2decodedpayload)
-public struct ResponseBodyV2DecodedPayload: DecodedSignedData, Decodable, Encodable, Hashable {
-    
+public struct ResponseBodyV2DecodedPayload: DecodedSignedData, Decodable, Encodable, Hashable, Sendable {
+
     public init(notificationType: NotificationTypeV2? = nil, subtype: Subtype? = nil, notificationUUID: String? = nil, data: Data? = nil, version: String? = nil, signedDate: Date? = nil, summary: Summary? = nil, externalPurchaseToken: ExternalPurchaseToken? = nil) {
         self.notificationType = notificationType
         self.subtype = subtype

--- a/Sources/AppStoreServerLibrary/Models/RevocationReason.swift
+++ b/Sources/AppStoreServerLibrary/Models/RevocationReason.swift
@@ -3,7 +3,7 @@
 ///The reason for a refunded transaction.
 ///
 ///[revocationReason](https://developer.apple.com/documentation/appstoreserverapi/revocationreason)
-public enum RevocationReason: Int32, Decodable, Encodable, Hashable {
+public enum RevocationReason: Int32, Decodable, Encodable, Hashable, Sendable {
     case refundedDueToIssue = 1
     case refundedForOtherReason = 0
 }

--- a/Sources/AppStoreServerLibrary/Models/SendAttemptItem.swift
+++ b/Sources/AppStoreServerLibrary/Models/SendAttemptItem.swift
@@ -4,7 +4,7 @@ import Foundation
 ///The success or error information and the date the App Store server records when it attempts to send a server notification to your server.
 ///
 ///[sendAttemptItem](https://developer.apple.com/documentation/appstoreserverapi/sendattemptitem)
-public struct SendAttemptItem: Decodable, Encodable, Hashable {
+public struct SendAttemptItem: Decodable, Encodable, Hashable, Sendable {
     
     public init(attemptDate: Date? = nil, sendAttemptResult: SendAttemptResult? = nil) {
         self.attemptDate = attemptDate

--- a/Sources/AppStoreServerLibrary/Models/SendAttemptResult.swift
+++ b/Sources/AppStoreServerLibrary/Models/SendAttemptResult.swift
@@ -3,7 +3,7 @@
 ///The success or error information the App Store server records when it attempts to send an App Store server notification to your server.
 ///
 ///[sendAttemptResult](https://developer.apple.com/documentation/appstoreserverapi/sendattemptresult)
-public enum SendAttemptResult: String, Decodable, Encodable, Hashable {
+public enum SendAttemptResult: String, Decodable, Encodable, Hashable, Sendable {
     case success = "SUCCESS"
     case timedOut = "TIMED_OUT"
     case tlsIssue = "TLS_ISSUE"

--- a/Sources/AppStoreServerLibrary/Models/SendTestNotificationResponse.swift
+++ b/Sources/AppStoreServerLibrary/Models/SendTestNotificationResponse.swift
@@ -3,7 +3,7 @@
 ///A response that contains the test notification token.
 ///
 ///[SendTestNotificationResponse](https://developer.apple.com/documentation/appstoreserverapi/sendtestnotificationresponse)
-public struct SendTestNotificationResponse: Decodable, Encodable, Hashable {
+public struct SendTestNotificationResponse: Decodable, Encodable, Hashable, Sendable {
 
     public init(testNotificationToken: String? = nil) {
         self.testNotificationToken = testNotificationToken

--- a/Sources/AppStoreServerLibrary/Models/Status.swift
+++ b/Sources/AppStoreServerLibrary/Models/Status.swift
@@ -3,7 +3,7 @@
 ///The status of an auto-renewable subscription.
 ///
 ///[status](https://developer.apple.com/documentation/appstoreserverapi/status)
-public enum Status: Int32, Decodable, Encodable, Hashable {
+public enum Status: Int32, Decodable, Encodable, Hashable, Sendable {
     case active = 1
     case expired = 2
     case billingRetry = 3

--- a/Sources/AppStoreServerLibrary/Models/StatusResponse.swift
+++ b/Sources/AppStoreServerLibrary/Models/StatusResponse.swift
@@ -3,7 +3,7 @@
 ///A response that contains status information for all of a customer’s auto-renewable subscriptions in your app.
 ///
 ///[StatusResponse](https://developer.apple.com/documentation/appstoreserverapi/statusresponse)
-public struct StatusResponse: Decodable, Encodable, Hashable {
+public struct StatusResponse: Decodable, Encodable, Hashable, Sendable {
     
     public init(environment: Environment? = nil, bundleId: String? = nil, appAppleId: Int64? = nil, data: [SubscriptionGroupIdentifierItem]? = nil) {
         self.environment = environment

--- a/Sources/AppStoreServerLibrary/Models/SubscriptionGroupIdentifierItem.swift
+++ b/Sources/AppStoreServerLibrary/Models/SubscriptionGroupIdentifierItem.swift
@@ -3,7 +3,7 @@
 ///Information for auto-renewable subscriptions, including signed transaction information and signed renewal information, for one subscription group.
 ///
 ///[SubscriptionGroupIdentifierItem](https://developer.apple.com/documentation/appstoreserverapi/subscriptiongroupidentifieritem)
-public struct SubscriptionGroupIdentifierItem: Decodable, Encodable, Hashable {
+public struct SubscriptionGroupIdentifierItem: Decodable, Encodable, Hashable, Sendable {
 
     public init(subscriptionGroupIdentifier: String? = nil, lastTransactions: [LastTransactionsItem]? = nil) {
         self.subscriptionGroupIdentifier = subscriptionGroupIdentifier

--- a/Sources/AppStoreServerLibrary/Models/Subtype.swift
+++ b/Sources/AppStoreServerLibrary/Models/Subtype.swift
@@ -3,7 +3,7 @@
 ///A string that provides details about select notification types in version 2.
 ///
 ///[subtype](https://developer.apple.com/documentation/appstoreservernotifications/subtype)
-public enum Subtype: String, Decodable, Encodable, Hashable {
+public enum Subtype: String, Decodable, Encodable, Hashable, Sendable {
     case initialBuy = "INITIAL_BUY"
     case resubscribe = "RESUBSCRIBE"
     case downgrade = "DOWNGRADE"

--- a/Sources/AppStoreServerLibrary/Models/Summary.swift
+++ b/Sources/AppStoreServerLibrary/Models/Summary.swift
@@ -3,7 +3,7 @@
 ///The payload data for a subscription-renewal-date extension notification.
 ///
 ///[summary](https://developer.apple.com/documentation/appstoreservernotifications/summary)
-public struct Summary: Decodable, Encodable, Hashable {
+public struct Summary: Decodable, Encodable, Hashable, Sendable {
     
     public init(environment: Environment? = nil, appAppleId: Int64? = nil, bundleId: String? = nil, productId: String? = nil, requestIdentifier: String? = nil, storefrontCountryCodes: [String]? = nil, succeededCount: Int64? = nil, failedCount: Int64? = nil) {
         self.environment = environment

--- a/Sources/AppStoreServerLibrary/Models/TransactionHistoryRequest.swift
+++ b/Sources/AppStoreServerLibrary/Models/TransactionHistoryRequest.swift
@@ -2,7 +2,7 @@
 
 import Foundation
 
-public struct TransactionHistoryRequest: Hashable {
+public struct TransactionHistoryRequest: Hashable, Sendable {
 
     public init(startDate: Date? = nil, endDate: Date? = nil, productIds: [String]? = nil, productTypes: [ProductType]? = nil, sort: Order? = nil, subscriptionGroupIdentifiers: [String]? = nil, inAppOwnershipType: InAppOwnershipType? = nil, revoked: Bool? = nil) {
         self.startDate = startDate
@@ -49,14 +49,14 @@ public struct TransactionHistoryRequest: Hashable {
     ///An optional Boolean value that indicates whether the response includes only revoked transactions when the value is true, or contains only nonrevoked transactions when the value is false. By default, the request doesn't include this parameter.
     public var revoked: Bool?
 
-    public enum ProductType: String, Decodable, Encodable {
+    public enum ProductType: String, Decodable, Encodable, Sendable {
         case autoRenewable = "AUTO_RENEWABLE"
         case nonRenewable = "NON_RENEWABLE"
         case consumable = "CONSUMABLE"
         case nonConsumable = "NON_CONSUMABLE"
     }
 
-    public enum Order: String, Decodable, Encodable {
+    public enum Order: String, Decodable, Encodable, Sendable {
         case ascending = "ASCENDING"
         case descending = "DESCENDING"
     }

--- a/Sources/AppStoreServerLibrary/Models/TransactionInfoResponse.swift
+++ b/Sources/AppStoreServerLibrary/Models/TransactionInfoResponse.swift
@@ -3,7 +3,7 @@
 ///A response that contains signed transaction information for a single transaction.
 ///
 ///[TransactionInfoResponse](https://developer.apple.com/documentation/appstoreserverapi/transactioninforesponse)
-public struct TransactionInfoResponse: Decodable, Encodable, Hashable {
+public struct TransactionInfoResponse: Decodable, Encodable, Hashable, Sendable {
 
     public init(signedTransactionInfo: String? = nil) {
         self.signedTransactionInfo = signedTransactionInfo

--- a/Sources/AppStoreServerLibrary/Models/TransactionReason.swift
+++ b/Sources/AppStoreServerLibrary/Models/TransactionReason.swift
@@ -3,7 +3,7 @@
 ///The cause of a purchase transaction, which indicates whether it’s a customer’s purchase or a renewal for an auto-renewable subscription that the system initiates.
 ///
 ///[transactionReason](https://developer.apple.com/documentation/appstoreserverapi/transactionreason)
-public enum TransactionReason: String, Decodable, Encodable, Hashable {
+public enum TransactionReason: String, Decodable, Encodable, Hashable, Sendable {
     case purchase = "PURCHASE"
     case renewal = "RENEWAL"
 }

--- a/Sources/AppStoreServerLibrary/Models/UserStatus.swift
+++ b/Sources/AppStoreServerLibrary/Models/UserStatus.swift
@@ -3,7 +3,7 @@
 ///The status of a customer’s account within your app.
 ///
 ///[userStatus](https://developer.apple.com/documentation/appstoreserverapi/userstatus)
-public enum UserStatus: Int32, Decodable, Encodable, Hashable {
+public enum UserStatus: Int32, Decodable, Encodable, Hashable, Sendable {
     case undeclared = 0
     case active = 1
     case suspended = 2


### PR DESCRIPTION
## WHY

- Support Sendable data models for Swift Concurrency.

## WHAT

- Conform data models to Sendable