### PR TITLE
Missing Hashable and Sendable Conformances

### DIFF
--- a/Sources/AppStoreServerLibrary/AppStoreServerAPIClient.swift
+++ b/Sources/AppStoreServerLibrary/AppStoreServerAPIClient.swift
@@ -9,7 +9,7 @@ import NIOFoundationCompat
 
 public class AppStoreServerAPIClient {
 
-    public enum ConfigurationError: Error {
+    public enum ConfigurationError: Error, Hashable, Sendable {
         /// Xcode is not a supported environment for an AppStoreServerAPIClient
         case invalidEnvironment
     }
@@ -345,7 +345,9 @@ public enum APIResult<T> {
     case failure(statusCode: Int?, rawApiError: Int64?, apiError: APIError?, errorMessage: String?, causedBy: Error?)
 }
 
-public enum APIError: Int64 {
+extension APIResult: Sendable where T: Sendable {}
+
+public enum APIError: Int64, Hashable, Sendable {
     ///An error that indicates an invalid request.
     ///
     ///[GeneralBadRequestError](https://developer.apple.com/documentation/appstoreserverapi/generalbadrequesterror)
@@ -633,7 +635,7 @@ public enum APIError: Int64 {
     case generalInternalRetryable = 5000001
 }
 
-public enum GetTransactionHistoryVersion: String {
+public enum GetTransactionHistoryVersion: String, Hashable, Sendable {
     @available(*, deprecated)
     case v1 = "v1"
     case v2 = "v2"

--- a/Sources/AppStoreServerLibrary/ChainVerifier.swift
+++ b/Sources/AppStoreServerLibrary/ChainVerifier.swift
@@ -226,6 +226,10 @@ public enum VerificationResult<T> {
     case invalid(VerificationError)
 }
 
+extension VerificationResult: Equatable where T: Equatable {}
+extension VerificationResult: Hashable where T: Hashable {}
+extension VerificationResult: Sendable where T: Sendable {}
+
 public enum VerificationError: Hashable, Sendable {
     case INVALID_JWT_FORMAT
     case INVALID_CERTIFICATE

--- a/Sources/AppStoreServerLibrary/SignedDataVerifier.swift
+++ b/Sources/AppStoreServerLibrary/SignedDataVerifier.swift
@@ -5,7 +5,7 @@ import Foundation
 ///A verifier and decoder class designed to decode signed data from the App Store.
 public struct SignedDataVerifier {
 
-    public enum ConfigurationError: Error {
+    public enum ConfigurationError: Error, Hashable, Sendable {
         case INVALID_APP_APPLE_ID
     }
 


### PR DESCRIPTION
Added missing Hashable and Sendable conformances, since I was getting warnings after updating to 3.0.0:

<img width="628" alt="image" src="https://github.com/user-attachments/assets/7ac5b468-9904-4410-a2ec-364bf4c07d61" />

I also audited the rest of the types and added it to some error types as well.