### PR TITLE
Add support for Set App Account Token endpoint

### DIFF
--- a/Sources/AppStoreServerLibrary/AppStoreServerAPIClient.swift
+++ b/Sources/AppStoreServerLibrary/AppStoreServerAPIClient.swift
@@ -325,6 +325,16 @@ public class AppStoreServerAPIClient {
     public func sendConsumptionData(transactionId: String, consumptionRequest: ConsumptionRequest) async -> APIResult<Void> {
         return await makeRequestWithoutResponseBody(path: "/inApps/v1/transactions/consumption/" + transactionId, method: .PUT, queryParameters: [:], body: consumptionRequest)
     }
+
+    ///Sets the app account token value for a purchase the customer makes outside your app, or updates its value in an existing transaction.
+    ///
+    ///- Parameter originalTransactionId: The original transaction identifier of the transaction to receive the app account token update.
+    ///- Parameter updateAppAccountTokenRequest :  The request body that contains a valid app account token value.
+    ///- Returns: Success, or information about the failure
+    ///[Set App Account Token](https://developer.apple.com/documentation/appstoreserverapi/set-app-account-token)
+    public func setAppAccountToken(originalTransactionId: String, updateAppAccountTokenRequest: UpdateAppAccountTokenRequest) async -> APIResult<Void> {
+        return await makeRequestWithoutResponseBody(path: "/inApps/v1/transactions/" + originalTransactionId + "/appAccountToken", method: .PUT, queryParameters: [:], body: updateAppAccountTokenRequest)
+    }
     
     internal struct AppStoreServerAPIJWT: JWTPayload, Equatable {
         var exp: ExpirationClaim
@@ -551,6 +561,21 @@ public enum APIError: Int64 {
     ///
     ///[AppTransactionIdNotSupportedError](https://developer.apple.com/documentation/appstoreserverapi/apptransactionidnotsupportederror)
     case appTransactionIdNotSupported = 4000048
+
+    ///An error that indicates the app account token value is not a valid UUID.
+    ///
+    ///[InvalidAppAccountTokenUUIDError](https://developer.apple.com/documentation/appstoreserverapi/invalidappaccounttokenuuiderror)
+    case invalidAppAccountTokenUUID = 4000183
+
+    ///An error that indicates the transaction is for a product the customer obtains through Family Sharing, which the endpoint doesn’t support.
+    ///
+    ///[FamilyTransactionNotSupportedError](https://developer.apple.com/documentation/appstoreserverapi/familytransactionnotsupportederror)
+    case familyTransactionNotSupported = 4000185
+
+    ///An error that indicates the endpoint expects an original transaction identifier.
+    ///
+    ///[TransactionIdIsNotOriginalTransactionIdError](https://developer.apple.com/documentation/appstoreserverapi/transactionidisnotoriginaltransactioniderror)
+    case transactionIdNotOriginalTransactionId = 4000187
 
     ///An error that indicates the subscription doesn't qualify for a renewal-date extension due to its subscription state.
     ///

--- a/Sources/AppStoreServerLibrary/Models/UpdateAppAccountTokenRequest.swift
+++ b/Sources/AppStoreServerLibrary/Models/UpdateAppAccountTokenRequest.swift
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 Apple Inc. Licensed under MIT License.
+
+import Foundation
+
+///The request body that contains an app account token value.
+///
+///[UpdateAppAccountTokenRequest](https://developer.apple.com/documentation/appstoreserverapi/updateappaccounttokenrequest)
+public struct UpdateAppAccountTokenRequest: Decodable, Encodable, Hashable, Sendable  {
+    ///The UUID that an app optionally generates to map a customer’s in-app purchase with its resulting App Store transaction.
+    ///
+    ///[appAccountToken](https://developer.apple.com/documentation/appstoreserverapi/appaccounttoken)
+    public let appAccountToken: UUID
+
+    public init(appAccountToken: UUID) {
+        self.appAccountToken = appAccountToken
+    }
+
+    public enum CodingKeys: CodingKey {
+        case appAccountToken
+    }
+
+    public init (from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.appAccountToken = try container.decode(UUID.self, forKey: .appAccountToken)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(self.appAccountToken, forKey: .appAccountToken)
+    }
+}

--- a/Tests/AppStoreServerLibraryTests/resources/models/familyTransactionNotSupportedError.json
+++ b/Tests/AppStoreServerLibraryTests/resources/models/familyTransactionNotSupportedError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4000185,
+  "errorMessage": "Invalid request. Family Sharing transactions aren't supported by this endpoint."
+}

--- a/Tests/AppStoreServerLibraryTests/resources/models/invalidAppAccountTokenUUIDError.json
+++ b/Tests/AppStoreServerLibraryTests/resources/models/invalidAppAccountTokenUUIDError.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4000183,
+  "errorMessage": "Invalid request. The app account token field must be a valid UUID."
+}

--- a/Tests/AppStoreServerLibraryTests/resources/models/transactionIdNotOriginalTransactionId.json
+++ b/Tests/AppStoreServerLibraryTests/resources/models/transactionIdNotOriginalTransactionId.json
@@ -1,0 +1,4 @@
+{
+  "errorCode": 4000187,
+  "errorMessage": "Invalid request. The transaction ID provided is not an original transaction ID."
+}


### PR DESCRIPTION
**Description**: Adding implementation for calling the Set App Account Token S2S using App Store Server Library.

For more info, please visit our developer documentation: https://developer.apple.com/documentation/appstoreserverapi/set-app-account-token