### PR TITLE
Sp/sendable client

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,8 +140,8 @@ let keyId = "ABCDEFGHIJ"
 let bundleId = "com.example"
 let encodedKey = try! String(contentsOfFile: "/path/to/key/SubscriptionKey_ABCDEFGHIJ.p8")
 
-let productId = "<product_id>"
-let subscriptionOfferId = "<subscription_offer_id>"
+let productIdentifier = "<product_id>"
+let subscriptionOfferID = "<subscription_offer_id>"
 let appAccountToken = "<app_account_token>"
 
 // try! used for example purposes only

--- a/README.md
+++ b/README.md
@@ -105,10 +105,11 @@ let client = AppStoreServerAPIClient(config: config)
 let appReceipt = "MI..."
 let transactionIdOptional = ReceiptUtility.extractTransactionId(appReceipt: appReceipt)
 if let transactionId = transactionIdOptional {
-    var transactionHistoryRequest = TransactionHistoryRequest()
-    transactionHistoryRequest.sort = TransactionHistoryRequest.Order.ascending
-    transactionHistoryRequest.revoked = false
-    transactionHistoryRequest.productTypes = [TransactionHistoryRequest.ProductType.autoRenewable]
+    let transactionHistoryRequest = TransactionHistoryRequest(
+        sort: .ascending,
+        revoked: false,
+        productTypes: [.autoRenewable]
+    )
 
     var response: HistoryResponse?
     var transactions: [String] = []

--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ let encodedKey = try! String(contentsOfFile: "/path/to/key/SubscriptionKey_ABCDE
 let environment = AppStoreEnvironment.sandbox
 
 // try! used for example purposes only
-let client = try! AppStoreServerAPIClient(signingKey: encodedKey, keyId: keyId, issuerId: issuerId, bundleId: bundleId, environment: environment)
+let config = try! AppStoreServerAPIConfiguration(signingKeyPem: encodedKey, keyId: keyId, issuerId: issuerId, bundleId: bundleId, environment: environment)
+let client = AppStoreServerAPIClient(config: config)
 
 let response = await client.requestTestNotification()
 switch response {
@@ -98,7 +99,8 @@ let encodedKey = try! String(contentsOfFile: "/path/to/key/SubscriptionKey_ABCDE
 let environment = AppStoreEnvironment.sandbox
 
 // try! used for example purposes only
-let client = try! AppStoreServerAPIClient(signingKey: encodedKey, keyId: keyId, issuerId: issuerId, bundleId: bundleId, environment: environment)
+let config = try! AppStoreServerAPIConfiguration(signingKeyPem: encodedKey, keyId: keyId, issuerId: issuerId, bundleId: bundleId, environment: environment)
+let client = AppStoreServerAPIClient(config: config)
 
 let appReceipt = "MI..."
 let transactionIdOptional = ReceiptUtility.extractTransactionId(appReceipt: appReceipt)


### PR DESCRIPTION
## Summary 
This PR implements a protocol-based testing approach inspired by Soto's AWSHTTPClient pattern, making AppStoreServerAPIClient conform to Sendable, and improves the overall architecture for better testability and concurrency safety.

## Protocol-Based HTTP Client Architecture
* Added AppStoreHTTPClient protocol for abstracting HTTP operations
* Made HTTPClient conform to AppStoreHTTPClient by extension
* Updated AppStoreServerAPIClient to accept any AppStoreHTTPClient for dependency injection & sharing the http pool
* Exposed httpClient through initializer with HTTPClient.shared as default so we share the http pool by default
* Removed manual deinit since HTTP client lifecycle is now managed externally

## Configuration Improvements
Created AppStoreServerAPIConfiguration struct for centralized configuration management
Added throwing configuration initializer for better error handling
Non-throwing client initializer for cleaner API usage

## Testing
Implemented MockHTTPClient for unit testing, since we couldn't extend the final Sendable class anymore
Updated test suite to use protocol-based mocking instead of inheritance


## Documentation Updates
Updated README to use new configuration-based syntax
Fixed variable name inconsistencies in code examples

## Breaking Changes
AppStoreServerAPIClient is now final - Cannot be subclassed
Configuration requires AppStoreServerAPIConfiguration - Old direct parameter initializer removed
HTTP client injection - Now accepts protocol instead of concrete type
