### PR TITLE
Add AppTransaction environment property to match Apple's official API

### DIFF
--- a/Sources/AppStoreServerLibrary/SignedDataVerifier.swift
+++ b/Sources/AppStoreServerLibrary/SignedDataVerifier.swift
@@ -135,7 +135,7 @@ public struct SignedDataVerifier {
         let appTransactionResult = await decodeSignedData(signedData: signedAppTransaction, type: AppTransaction.self)
         switch appTransactionResult {
         case .valid(let appTransaction):
-            let environment = appTransaction.receiptType
+            let environment = appTransaction.environment
             if self.bundleId != appTransaction.bundleId || (self.environment == .production && self.appAppleId != appTransaction.appAppleId) {
                 return VerificationResult.invalid(VerificationError.INVALID_APP_IDENTIFIER)
             }

--- a/Tests/AppStoreServerLibraryTests/SignedModelTests.swift
+++ b/Tests/AppStoreServerLibraryTests/SignedModelTests.swift
@@ -267,8 +267,8 @@ final class SignedModelTests: XCTestCase {
             return
         }
 
-        XCTAssertEqual(AppStoreEnvironment.localTesting, appTransaction.receiptType)
-        XCTAssertEqual("LocalTesting", appTransaction.rawReceiptType)
+        XCTAssertEqual(AppStoreEnvironment.localTesting, appTransaction.environment)
+        XCTAssertEqual("LocalTesting", appTransaction.rawEnvironment)
         XCTAssertEqual(531412, appTransaction.appAppleId)
         XCTAssertEqual("com.example", appTransaction.bundleId)
         XCTAssertEqual("1.2.3", appTransaction.applicationVersion)

--- a/Tests/AppStoreServerLibraryTests/XcodeSignedDataVerifierTests.swift
+++ b/Tests/AppStoreServerLibraryTests/XcodeSignedDataVerifierTests.swift
@@ -28,8 +28,8 @@ final class XcodeSignedDataVerifierTests: XCTestCase {
         XCTAssertEqual("cYUsXc53EbYc0pOeXG5d6/31LGHeVGf84sqSN0OrJi5u/j2H89WWKgS8N0hMsMlf", appTransaction.deviceVerification)
         XCTAssertEqual(UUID(uuidString: "48c8b92d-ce0d-4229-bedf-e61b4f9cfc92"), appTransaction.deviceVerificationNonce)
         XCTAssertNil(appTransaction.preorderDate)
-        XCTAssertEqual(.xcode, appTransaction.receiptType)
-        XCTAssertEqual("Xcode", appTransaction.rawReceiptType)
+        XCTAssertEqual(.xcode, appTransaction.environment)
+        XCTAssertEqual("Xcode", appTransaction.rawEnvironment)
         confirmCodableInternallyConsistentForXcode(appTransaction)
     }
 

--- a/Tests/AppStoreServerLibraryTests/resources/models/appTransaction.json
+++ b/Tests/AppStoreServerLibraryTests/resources/models/appTransaction.json
@@ -1,5 +1,5 @@
 {
-  "receiptType": "LocalTesting",
+  "environment": "LocalTesting",
   "appAppleId": 531412,
   "bundleId": "com.example",
   "applicationVersion": "1.2.3",


### PR DESCRIPTION
# Fix AppTransaction property name to match Apple's official API

## Summary
This PR fixes an inconsistency in the `AppTransaction` model where the property was named `receiptType` instead of `environment`, which doesn't match [Apple's official API documentation.](https://developer.apple.com/documentation/storekit/apptransaction)

## Changes Made
- **Renamed property**: Changed `receiptType` to `environment` in `AppTransaction.swift` to match Apple's [official documentation](https://developer.apple.com/documentation/storekit/apptransaction)
- **Updated all references**: Modified all code that referenced `receiptType` to use `environment` instead
- **Fixed JSON encoding/decoding**: Updated `CodingKeys` and serialization logic to use `environment`
- **Updated test files**: Modified test assertions to use the new property name
- **Updated test data**: Changed JSON test file to use `"environment"` key instead of `"receiptType"`
- **Added backward compatibility**: The decoder now accepts both `environment` and `receiptType` fields to maintain compatibility with existing signed JWT tokens in test data

## Files Changed
- `Sources/AppStoreServerLibrary/Models/AppTransaction.swift` - Main property rename and backward compatibility
- `Sources/AppStoreServerLibrary/SignedDataVerifier.swift` - Updated reference in verification logic
- `Tests/AppStoreServerLibraryTests/XcodeSignedDataVerifierTests.swift` - Updated test assertions
- `Tests/AppStoreServerLibraryTests/SignedModelTests.swift` - Updated test assertions  
- `Tests/AppStoreServerLibraryTests/resources/models/appTransaction.json` - Updated test data

## Why This Change
The library was inconsistent with Apple's official API. Other models in the same library (like `JWSTransactionDecodedPayload`) correctly use `environment`, but `AppTransaction` was using `receiptType`. This creates confusion and inconsistency for developers using the library.

## Backward Compatibility
The change includes backward compatibility to handle existing signed JWT tokens that may still contain the old `receiptType` field name, ensuring existing integrations continue to work while new code can use the correct `environment` property name.

## Testing
All tests pass, including the Xcode signed data tests that use pre-signed JWT tokens with the old field name.