### PR TITLE
Use JWTKit for decoding JWTs

### DIFF
--- a/Sources/AppStoreServerLibrary/ChainVerifier.swift
+++ b/Sources/AppStoreServerLibrary/ChainVerifier.swift
@@ -10,7 +10,6 @@ import NIOFoundationCompat
 
 actor ChainVerifier {
     private static let EXPECTED_CHAIN_LENGTH = 3
-    private static let EXPECTED_JWT_SEGMENTS = 3
     private static let EXPECTED_ALGORITHM = "ES256"
     
     private static let MAXIMUM_CACHE_SIZE = 32 // There are unlikely to be more than a couple keys at once
@@ -28,19 +27,13 @@ actor ChainVerifier {
     }
     
     func verify<T: DecodedSignedData>(signedData: String, type: T.Type, onlineVerification: Bool, environment: AppStoreEnvironment, currentTime: Date = .now) async -> VerificationResult<T> where T: Decodable & Sendable {
-        let header: JWTHeader
+        let header: JWTKit.JWTHeader
+        let parser = DefaultJWTParser(jsonDecoder: getJsonDecoder())
         let decodedBody: T
+        let dataToken = Data(signedData.utf8)
+
         do {
-            let bodySegments = signedData.components(separatedBy: ".")
-            if (bodySegments.count != ChainVerifier.EXPECTED_JWT_SEGMENTS) {
-                return VerificationResult.invalid(VerificationError.INVALID_JWT_FORMAT)
-            }
-            let jsonDecoder = getJsonDecoder()
-            guard let headerData = Data(base64Encoded: base64URLToBase64(bodySegments[0])), let bodyData = Data(base64Encoded: base64URLToBase64(bodySegments[1])) else {
-                return VerificationResult.invalid(VerificationError.INVALID_JWT_FORMAT)
-            }
-            header = try jsonDecoder.decode(JWTHeader.self, from: headerData)
-            decodedBody = try jsonDecoder.decode(type, from: bodyData)
+            (header, decodedBody, _) = try parser.parse(dataToken, as: type)
         } catch {
             return VerificationResult.invalid(VerificationError.INVALID_JWT_FORMAT)
         }
@@ -149,11 +142,6 @@ struct VaporBody : JWTPayload {
     func verify(using algorithm: some JWTAlgorithm) async throws {
         // No-op
     }
-}
-
-struct JWTHeader: Decodable, Encodable {
-    public var alg: String?
-    public var x5c: [String]?
 }
 
 final class AppStoreOIDPolicy: VerifierPolicy {

--- a/Sources/AppStoreServerLibrary/Models/AppTransaction.swift
+++ b/Sources/AppStoreServerLibrary/Models/AppTransaction.swift
@@ -1,6 +1,7 @@
 // Copyright (c) 2023 Apple Inc. Licensed under MIT License.
 
 import Foundation
+import JWTKit
 
 
 ///A decoded payload that contains app transaction information.
@@ -184,4 +185,6 @@ public struct AppTransaction: DecodedSignedData, Decodable, Encodable, Hashable,
         try container.encodeIfPresent(self.appTransactionId, forKey: .appTransactionId)
         try container.encodeIfPresent(self.rawOriginalPlatform, forKey: .originalPlatform)
     }
+
+    public func verify(using algorithm: some JWTKit.JWTAlgorithm) async throws {}
 }

--- a/Sources/AppStoreServerLibrary/Models/DecodedRealtimeRequestBody.swift
+++ b/Sources/AppStoreServerLibrary/Models/DecodedRealtimeRequestBody.swift
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 Apple Inc. Licensed under MIT License.
 
 import Foundation
+import JWTKit
 
 ///The decoded request body the App Store sends to your server to request a real-time retention message.
 ///
@@ -102,4 +103,6 @@ public struct DecodedRealtimeRequestBody: DecodedSignedData, Decodable, Encodabl
         try container.encode(self.signedDate, forKey: .signedDate)
         try container.encode(self.rawEnvironment, forKey: .environment)
     }
+
+    public func verify(using algorithm: some JWTKit.JWTAlgorithm) async throws {}
 }

--- a/Sources/AppStoreServerLibrary/Models/DecodedSignedData.swift
+++ b/Sources/AppStoreServerLibrary/Models/DecodedSignedData.swift
@@ -1,7 +1,8 @@
 // Copyright (c) 2023 Apple Inc. Licensed under MIT License.
 
 import Foundation
+import JWTKit
 
-protocol DecodedSignedData {
+protocol DecodedSignedData: JWTPayload {
     var signedDateOptional: Date? { get }
 }

--- a/Sources/AppStoreServerLibrary/Models/JWSRenewalInfoDecodedPayload.swift
+++ b/Sources/AppStoreServerLibrary/Models/JWSRenewalInfoDecodedPayload.swift
@@ -1,6 +1,8 @@
 // Copyright (c) 2023 Apple Inc. Licensed under MIT License.
 
 import Foundation
+import JWTKit
+
 ///A decoded payload containing subscription renewal information for an auto-renewable subscription.
 ///
 ///[JWSRenewalInfoDecodedPayload](https://developer.apple.com/documentation/appstoreserverapi/jwsrenewalinfodecodedpayload)
@@ -296,4 +298,6 @@ public struct JWSRenewalInfoDecodedPayload: DecodedSignedData, Decodable, Encoda
         try container.encodeIfPresent(self.appTransactionId, forKey: .appTransactionId)
         try container.encodeIfPresent(self.offerPeriod, forKey: .offerPeriod)
     }
+
+    public func verify(using algorithm: some JWTKit.JWTAlgorithm) async throws {}
 }

--- a/Sources/AppStoreServerLibrary/Models/JWSTransactionDecodedPayload.swift
+++ b/Sources/AppStoreServerLibrary/Models/JWSTransactionDecodedPayload.swift
@@ -1,6 +1,8 @@
 // Copyright (c) 2023 Apple Inc. Licensed under MIT License.
 
 import Foundation
+import JWTKit
+
 ///A decoded payload containing transaction information.
 ///
 ///[JWSTransactionDecodedPayload](https://developer.apple.com/documentation/appstoreserverapi/jwstransactiondecodedpayload)
@@ -406,4 +408,6 @@ public struct JWSTransactionDecodedPayload: DecodedSignedData, Decodable, Encoda
         try container.encodeIfPresent(self.rawRevocationType, forKey: .revocationType)
         try container.encodeIfPresent(self.revocationPercentage, forKey: .revocationPercentage)
     }
+
+    public func verify(using algorithm: some JWTKit.JWTAlgorithm) async throws {}
 }

--- a/Sources/AppStoreServerLibrary/Models/ResponseBodyV2DecodedPayload.swift
+++ b/Sources/AppStoreServerLibrary/Models/ResponseBodyV2DecodedPayload.swift
@@ -1,6 +1,8 @@
 // Copyright (c) 2023 Apple Inc. Licensed under MIT License.
 
 import Foundation
+import JWTKit
+
 ///A decoded payload containing the version 2 notification data.
 ///
 ///[responseBodyV2DecodedPayload](https://developer.apple.com/documentation/appstoreservernotifications/responsebodyv2decodedpayload)
@@ -139,4 +141,6 @@ public struct ResponseBodyV2DecodedPayload: DecodedSignedData, Decodable, Encoda
         try container.encodeIfPresent(self.externalPurchaseToken, forKey: .externalPurchaseToken)
         try container.encodeIfPresent(self.appData, forKey: .appData)
     }
+
+    public func verify(using algorithm: some JWTKit.JWTAlgorithm) async throws {}
 }

--- a/Sources/AppStoreServerLibrary/Utility.swift
+++ b/Sources/AppStoreServerLibrary/Utility.swift
@@ -2,16 +2,6 @@
 
 import Foundation
 
-internal func base64URLToBase64(_ encodedString: String) -> String {
-    let replacedString = encodedString
-        .replacingOccurrences(of: "-", with: "+")
-        .replacingOccurrences(of: "_", with: "/")
-    if (replacedString.count % 4 != 0) {
-        return replacedString + String(repeating: "=", count: 4 - replacedString.count % 4)
-    }
-    return replacedString
-}
-
 internal func getJsonDecoder() -> JSONDecoder  {
     let decoder = JSONDecoder()
     decoder.dateDecodingStrategy = .millisecondsSince1970


### PR DESCRIPTION
~~This PR aims to reduce the custom JWT/JWS code in the library since most of the functions are already present in JWTKit. X5C verification is replaced with JWTKit's `X5CVerifier` (besides custom rules, for example the mandatory x5c certificate count).
Custom JWT signing is also replaced with JWTKit.~~

Since the library already imports JWTKit we can use it to decode the token. The various token types now conform to `JWTPayload` to make this possible. The required verification methods are empty since they're not being used, verification is happening manually.