### PR TITLE
Use `.shared` HTTPClient

### DIFF
--- a/Sources/AppStoreServerLibrary/AppStoreServerAPIClient.swift
+++ b/Sources/AppStoreServerLibrary/AppStoreServerAPIClient.swift
@@ -25,7 +25,7 @@ public actor AppStoreServerAPIClient: Sendable {
     private let issuerId: String
     private let bundleId: String
     private let url: String
-    private let client: HTTPClient
+    private let client: HTTPClient = .shared
     // For testing purposes
     private var executeRequestOverride: (@Sendable (HTTPClientRequest, Data?) async throws -> HTTPClientResponse)?
 
@@ -54,11 +54,6 @@ public actor AppStoreServerAPIClient: Sendable {
             self.url = AppStoreServerAPIClient.sandboxUrl
             break
         }
-        self.client = .init()
-    }
-    
-    deinit {
-        try? self.client.syncShutdown()
     }
 
     // Test helper method to set request override

--- a/Sources/AppStoreServerLibrary/ChainVerifier.swift
+++ b/Sources/AppStoreServerLibrary/ChainVerifier.swift
@@ -191,11 +191,7 @@ final class Requester: OCSPRequester {
 
     static let OCSP_NETWORK_REQUEST_FAILED = "OCSP_NETWORK_REQUEST_FAILED"
 
-    private let client: HTTPClient
-
-    init() {
-        self.client = .init()
-    }
+    private let client: HTTPClient = .shared
 
     func query(request: [UInt8], uri: String) async -> X509.OCSPRequesterQueryResult {
         do {
@@ -220,10 +216,6 @@ final class Requester: OCSPRequester {
         } catch {
             return .terminalError(OCSPValidationError.networkError(underlyingError: error))
         }
-    }
-
-    deinit {
-        try? self.client.syncShutdown()
     }
 
     enum OCSPValidationError: Error, CustomStringConvertible {


### PR DESCRIPTION
Fixes #113, which I've also hit