### PR TITLE
Fix compile errors in README usage examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ let signatureCreator = try! PromotionalOfferSignatureCreator(privateKey: encoded
 
 let nonce = UUID()
 let timestamp = Int64(Date().timeIntervalSince1970) * 1000
-let signature = signatureCreator.createSignature(productIdentifier: productIdentifier, subscriptionOfferID: subscriptionOfferID, appAccountToken: appAccountToken, nonce: nonce, timestamp: timestamp)
+let signature = try! signatureCreator.createSignature(productIdentifier: productId, subscriptionOfferID: subscriptionOfferId, appAccountToken: appAccountToken, nonce: nonce, timestamp: timestamp)
 print(signature)
 ```
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ let verifier = try! SignedDataVerifier(rootCertificates: appleRootCAs, bundleId:
 let notificationPayload = "ey..."
 let notificationResult = await verifier.verifyAndDecodeNotification(signedPayload: notificationPayload)
 switch notificationResult {
-case .valid(let decodedNotificaiton):
+case .valid(let decodedNotification):
     ...
 case .invalid(let error):
     ...

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ if let transactionId = transactionIdOptional {
         case .success(let successfulResponse):
             response = successfulResponse
         case .failure:
-            // Handle Failure
-            throw
+            // Handle failure; fatalError used for example purposes only
+            fatalError("Failed to fetch transaction history")
         }
         if let signedTransactions = response?.signedTransactions {
             transactions.append(contentsOf: signedTransactions)

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ if let transactionId = transactionIdOptional {
     var transactions: [String] = []
     repeat {
         let revisionToken = response?.revision
-        let apiResponse = await client.getTransactionHistory(transactionId: transactionId, revision: revisionToken, transactionHistoryRequest: transactionHistoryRequest, version: .v2)
+        let apiResponse = await client.getTransactionHistory(anyTransactionId: transactionId, revision: revisionToken, transactionHistoryRequest: transactionHistoryRequest, version: .v2)
         switch apiResponse {
         case .success(let successfulResponse):
             response = successfulResponse


### PR DESCRIPTION
The README's usage examples contain several errors that make them fail to compile if copy-pasted. One commit per fix:

1. **Receipt Usage — wrong argument label**: the example calls `client.getTransactionHistory(transactionId: ...)`, but the API's parameter is `anyTransactionId:` (`AppStoreServerAPIClient.swift`), so the call does not compile.
2. **Receipt Usage — bare `throw`**: `throw` without an expression is not valid Swift (and the example isn't in a throwing context). Replaced with `fatalError` plus a note, matching the "`try!` used for example purposes only" convention this README already uses.
3. **Promotional Offer Signature Creation — undefined variables + missing `try`**: the example defines `productId` and `subscriptionOfferId` but passes the undefined identifiers `productIdentifier`/`subscriptionOfferID` as arguments, and `createSignature` throws but was called without `try`. Now passes the defined variables (labels unchanged — they match the API) with `try!`.
4. **Verification Usage — misspelled binding**: `decodedNotificaiton` → `decodedNotification`.

Each fix was verified against the current API signatures in `Sources/AppStoreServerLibrary` (`createSignature(productIdentifier:subscriptionOfferID:appAccountToken:nonce:timestamp:) throws`, `getTransactionHistory(anyTransactionId:...)`).

**Verification:** `swift build` passes; `swift test` runs 155 tests with 154 passing locally (macOS arm64, Swift 6.3.3) — the single failure, `testAppleChainIsValidWithOCSP`, performs a live OCSP network request and fails identically on unmodified `main` in this environment; this PR's diff touches only `README.md`.

Prepared with AI assistance (Claude); every example was checked against the library source as described.