### PR TITLE
Add tokenType field to ExternalPurchaseToken model

### DIFF
--- a/Sources/AppStoreServerLibrary/Models/ExternalPurchaseToken.swift
+++ b/Sources/AppStoreServerLibrary/Models/ExternalPurchaseToken.swift
@@ -5,11 +5,16 @@
 ///[externalPurchaseToken](https://developer.apple.com/documentation/appstoreservernotifications/externalpurchasetoken)
 public struct ExternalPurchaseToken: Decodable, Encodable, Hashable, Sendable {
     
-    public init(externalPurchaseId: String? = nil, tokenCreationDate: Int64? = nil, appAppleId: Int64? = nil, bundleId: String? = nil) {
+    public init(externalPurchaseId: String? = nil, tokenCreationDate: Int64? = nil, appAppleId: Int64? = nil, bundleId: String? = nil, tokenType: TokenType? = nil) {
+        self.init(externalPurchaseId: externalPurchaseId, tokenCreationDate: tokenCreationDate, appAppleId: appAppleId, bundleId: bundleId, rawTokenType: tokenType?.rawValue)
+    }
+
+    public init(externalPurchaseId: String? = nil, tokenCreationDate: Int64? = nil, appAppleId: Int64? = nil, bundleId: String? = nil, rawTokenType: String? = nil) {
         self.externalPurchaseId = externalPurchaseId
         self.tokenCreationDate = tokenCreationDate
         self.appAppleId = appAppleId
         self.bundleId = bundleId
+        self.rawTokenType = rawTokenType
     }
 
     ///The field of an external purchase token that uniquely identifies the token.
@@ -31,4 +36,45 @@ public struct ExternalPurchaseToken: Decodable, Encodable, Hashable, Sendable {
     ///
     ///[bundleId](https://developer.apple.com/documentation/appstoreservernotifications/bundleid)
     public var bundleId: String?
+
+    ///The custom link token type.
+    ///
+    ///[tokenType](https://developer.apple.com/documentation/appstoreservernotifications/tokentype)
+    public var tokenType: TokenType? {
+        get {
+            return rawTokenType.flatMap { TokenType(rawValue: $0) }
+        }
+        set {
+            self.rawTokenType = newValue.map { $0.rawValue }
+        }
+    }
+
+    ///See ``tokenType``
+    public var rawTokenType: String?
+
+    public enum CodingKeys: CodingKey {
+        case externalPurchaseId
+        case tokenCreationDate
+        case appAppleId
+        case bundleId
+        case tokenType
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.externalPurchaseId = try container.decodeIfPresent(String.self, forKey: .externalPurchaseId)
+        self.tokenCreationDate = try container.decodeIfPresent(Int64.self, forKey: .tokenCreationDate)
+        self.appAppleId = try container.decodeIfPresent(Int64.self, forKey: .appAppleId)
+        self.bundleId = try container.decodeIfPresent(String.self, forKey: .bundleId)
+        self.rawTokenType = try container.decodeIfPresent(String.self, forKey: .tokenType)
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(self.externalPurchaseId, forKey: .externalPurchaseId)
+        try container.encodeIfPresent(self.tokenCreationDate, forKey: .tokenCreationDate)
+        try container.encodeIfPresent(self.appAppleId, forKey: .appAppleId)
+        try container.encodeIfPresent(self.bundleId, forKey: .bundleId)
+        try container.encodeIfPresent(self.rawTokenType, forKey: .tokenType)
+    }
 }

--- a/Sources/AppStoreServerLibrary/Models/TokenType.swift
+++ b/Sources/AppStoreServerLibrary/Models/TokenType.swift
@@ -1,0 +1,9 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+///The type of an external purchase custom link token.
+///
+///[tokenType](https://developer.apple.com/documentation/appstoreservernotifications/tokentype)
+public enum TokenType: String, Decodable, Encodable, Hashable, Sendable {
+    case acquisition = "ACQUISITION"
+    case services = "SERVICES"
+}

--- a/Tests/AppStoreServerLibraryTests/SignedModelTests.swift
+++ b/Tests/AppStoreServerLibraryTests/SignedModelTests.swift
@@ -134,6 +134,8 @@ final class SignedModelTests: XCTestCase {
         XCTAssertEqual(1698148950000, notification.externalPurchaseToken!.tokenCreationDate)
         XCTAssertEqual(55555, notification.externalPurchaseToken!.appAppleId)
         XCTAssertEqual("com.example", notification.externalPurchaseToken!.bundleId)
+        XCTAssertNil(notification.externalPurchaseToken!.tokenType)
+        XCTAssertNil(notification.externalPurchaseToken!.rawTokenType)
         TestingUtility.confirmCodableInternallyConsistent(notification)
     }
     
@@ -166,9 +168,45 @@ final class SignedModelTests: XCTestCase {
         XCTAssertEqual(1698148950000, notification.externalPurchaseToken!.tokenCreationDate)
         XCTAssertEqual(55555, notification.externalPurchaseToken!.appAppleId)
         XCTAssertEqual("com.example", notification.externalPurchaseToken!.bundleId)
+        XCTAssertNil(notification.externalPurchaseToken!.tokenType)
+        XCTAssertNil(notification.externalPurchaseToken!.rawTokenType)
         TestingUtility.confirmCodableInternallyConsistent(notification)
     }
-    
+
+    public func testExternalPurchaseTokenWithTokenTypeNotificationDecoding() async throws {
+        let signedNotification = TestingUtility.createSignedDataFromJson("resources/models/signedExternalPurchaseTokenNotificationWithTokenType.json")
+
+        let verifiedNotification = await TestingUtility.getSignedDataVerifier().verifyAndDecodeNotification(signedPayload: signedNotification) { bundleId, appAppleId, environment in
+            XCTAssertEqual("com.example", bundleId)
+            XCTAssertEqual(55555, appAppleId)
+            XCTAssertEqual(.production, environment)
+            return nil
+        }
+
+        guard case .valid(let notification) = verifiedNotification else {
+            XCTAssertTrue(false)
+            return
+        }
+
+        XCTAssertEqual(NotificationTypeV2.externalPurchaseToken, notification.notificationType)
+        XCTAssertEqual("EXTERNAL_PURCHASE_TOKEN", notification.rawNotificationType)
+        XCTAssertEqual(Subtype.unreported, notification.subtype)
+        XCTAssertEqual("UNREPORTED", notification.rawSubtype)
+        XCTAssertEqual("002e14d5-51f5-4503-b5a8-c3a1af68eb20", notification.notificationUUID)
+        XCTAssertEqual("2.0", notification.version)
+        XCTAssertEqual(Date(timeIntervalSince1970: 1698148900), notification.signedDate)
+        XCTAssertNil(notification.data)
+        XCTAssertNil(notification.summary)
+        XCTAssertNotNil(notification.externalPurchaseToken)
+        XCTAssertEqual("b2158121-7af9-49d4-9561-1f588205523e", notification.externalPurchaseToken!.externalPurchaseId)
+        XCTAssertEqual(1698148950000, notification.externalPurchaseToken!.tokenCreationDate)
+        XCTAssertEqual(55555, notification.externalPurchaseToken!.appAppleId)
+        XCTAssertEqual("com.example", notification.externalPurchaseToken!.bundleId)
+        XCTAssertEqual(notification.externalPurchaseToken!.tokenType, .acquisition)
+        XCTAssertEqual(notification.externalPurchaseToken!.rawTokenType, "ACQUISITION")
+        TestingUtility.confirmCodableInternallyConsistent(notification)
+    }
+
     public func testTransactionDecoding() async throws {
         let signedTransaction = TestingUtility.createSignedDataFromJson("resources/models/signedTransaction.json")
 

--- a/Tests/AppStoreServerLibraryTests/resources/models/signedExternalPurchaseTokenNotificationWithTokenType.json
+++ b/Tests/AppStoreServerLibraryTests/resources/models/signedExternalPurchaseTokenNotificationWithTokenType.json
@@ -1,0 +1,14 @@
+{
+    "notificationType": "EXTERNAL_PURCHASE_TOKEN",
+    "subtype": "UNREPORTED",
+    "notificationUUID": "002e14d5-51f5-4503-b5a8-c3a1af68eb20",
+    "version": "2.0",
+    "signedDate": 1698148900000,
+    "externalPurchaseToken": {
+      "externalPurchaseId": "b2158121-7af9-49d4-9561-1f588205523e",
+      "tokenCreationDate": 1698148950000,
+      "appAppleId": 55555,
+      "bundleId": "com.example",
+      "tokenType": "ACQUISITION"
+    }
+  }


### PR DESCRIPTION
Description: Adding tokenType field to ExternalPurchaseToken model.

For more info, please visit developer documentation: https://developer.apple.com/documentation/appstoreservernotifications/externalpurchasetoken