### PR TITLE
Add AppReceiptVerifier for signature validation of legacy app receipts

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -37,7 +37,11 @@ let package = Package(
             ]),
         .testTarget(
             name: "AppStoreServerLibraryTests",
-            dependencies: ["AppStoreServerLibrary"],
+            dependencies: [
+                "AppStoreServerLibrary",
+                // Generates the throwaway RSA keys the app receipt test PKI signs with
+                .product(name: "_CryptoExtras", package: "swift-crypto"),
+            ],
             resources: [.copy("resources")]
         ),
     ]

--- a/README.md
+++ b/README.md
@@ -128,6 +128,38 @@ if let transactionId = transactionIdOptional {
 }
 ```
 
+### App Receipt Verification Usage
+
+```swift
+import AppStoreServerLibrary
+
+let bundleId = "com.example"
+let appleRootCAs = loadRootCAs() // Specific implementation may vary
+let enableOnlineChecks = true
+let environment = AppStoreEnvironment.sandbox
+
+// try! used for example purposes only
+let verifier = try! AppReceiptVerifier(rootCertificates: appleRootCAs, bundleId: bundleId, environment: environment, enableOnlineChecks: enableOnlineChecks)
+
+let appReceipt = "MI..."
+let receiptResult = await verifier.verifyAndDecodeAppReceipt(encodedReceipt: appReceipt)
+switch receiptResult {
+case .valid(let decodedReceipt):
+    ...
+case .invalid(let error):
+    ...
+}
+
+let transactionIdResult = await verifier.verifyAndExtractTransactionId(encodedReceipt: appReceipt)
+switch transactionIdResult {
+case .valid(let transactionIdOptional):
+    // nil when the receipt contains no in-app purchases
+    ...
+case .invalid(let error):
+    ...
+}
+```
+
 ### Promotional Offer Signature Creation
 
 ```swift

--- a/Sources/AppStoreServerLibrary/AppReceiptVerifier.swift
+++ b/Sources/AppStoreServerLibrary/AppReceiptVerifier.swift
@@ -37,6 +37,7 @@ public struct AppReceiptVerifier: Sendable {
     private static let IAP_IS_IN_INTRO_OFFER_PERIOD = Int64(1719)
 
     private static let EXPECTED_CHAIN_LENGTH = 3
+    private static let MAXIMUM_EMBEDDED_CERTIFICATES = 10
 
     private var bundleId: String
     private var environment: AppStoreEnvironment
@@ -103,8 +104,12 @@ public struct AppReceiptVerifier: Sendable {
     }
 
     ///Verifies an app receipt and extracts a transaction id from its in-app purchases, the validated counterpart of
-    ///``ReceiptUtility/extractTransactionId(appReceipt:)`` with the same output contract: a transaction id from the
-    ///array of in-app purchases, or nil if the receipt contains none.
+    ///``ReceiptUtility/extractTransactionId(appReceipt:)``: a transaction id from the array of in-app purchases, or
+    ///nil if the receipt contains none.
+    ///
+    ///Which id, for a receipt carrying several, is deterministic here and is not the one ``ReceiptUtility`` returns:
+    ///this takes the first in-app purchase that carries an identifier, preferring its transaction id over its
+    ///original transaction id, where ``ReceiptUtility`` keeps overwriting and so yields the last.
     ///
     ///- Parameter encodedReceipt The base64-encoded app receipt
     ///- Returns: If success, a transaction id from the receipt's in-app purchases, nil if the receipt contains no
@@ -131,6 +136,12 @@ public struct AppReceiptVerifier: Sendable {
     ///leaf OID, and validates to the caller-supplied Apple roots. As with JWS signed data, the root of the chain comes
     ///from the caller, not from the receipt.
     private func verifyChain(signedData: PKCS7SignedData, effectiveDate: Date) async -> VerificationResult<Certificate> {
+        // The embedded certificates are attacker-supplied and are ordered into a chain below, before anything about
+        // the receipt has been verified, so a receipt carrying more of them than a chain can hold is rejected here
+        // rather than assembled.
+        guard signedData.certificates.count <= AppReceiptVerifier.MAXIMUM_EMBEDDED_CERTIFICATES else {
+            return VerificationResult.invalid(VerificationError.VERIFICATION_FAILURE)
+        }
         guard let leaf = signedData.signerCertificate() else {
             return VerificationResult.invalid(VerificationError.INVALID_CERTIFICATE)
         }

--- a/Sources/AppStoreServerLibrary/AppReceiptVerifier.swift
+++ b/Sources/AppStoreServerLibrary/AppReceiptVerifier.swift
@@ -1,0 +1,574 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import Foundation
+import Crypto
+import SwiftASN1
+import X509
+
+///A verifier and decoder class for legacy PKCS#7 App Store receipts, the app receipt used with the deprecated
+///`verifyReceipt` endpoint.
+///
+///This is the validating counterpart to ``ReceiptUtility``, which extracts without validation. The receipt's
+///certificate chain is validated with the same chain verification used for JWS signed data, against the same
+///caller-supplied Apple root certificates, and evaluated at the receipt's creation date so old receipts survive
+///certificate rotations unless online checks are enabled.
+public struct AppReceiptVerifier: Sendable {
+
+    private static let ATTR_RECEIPT_TYPE = Int64(0)
+    private static let ATTR_BUNDLE_ID = Int64(2)
+    private static let ATTR_APP_VERSION = Int64(3)
+    private static let ATTR_OPAQUE_VALUE = Int64(4)
+    private static let ATTR_SHA1_HASH = Int64(5)
+    private static let ATTR_CREATION_DATE = Int64(12)
+    private static let ATTR_IN_APP = Int64(17)
+    private static let ATTR_ORIGINAL_PURCHASE_DATE = Int64(18)
+    private static let ATTR_ORIGINAL_APP_VERSION = Int64(19)
+    private static let ATTR_EXPIRATION_DATE = Int64(21)
+
+    private static let IAP_QUANTITY = Int64(1701)
+    private static let IAP_PRODUCT_ID = Int64(1702)
+    private static let IAP_TRANSACTION_ID = Int64(1703)
+    private static let IAP_PURCHASE_DATE = Int64(1704)
+    private static let IAP_ORIGINAL_TRANSACTION_ID = Int64(1705)
+    private static let IAP_ORIGINAL_PURCHASE_DATE = Int64(1706)
+    private static let IAP_EXPIRES_DATE = Int64(1708)
+    private static let IAP_WEB_ORDER_LINE_ITEM_ID = Int64(1711)
+    private static let IAP_CANCELLATION_DATE = Int64(1712)
+    private static let IAP_IS_IN_INTRO_OFFER_PERIOD = Int64(1719)
+
+    private static let EXPECTED_CHAIN_LENGTH = 3
+
+    private var bundleId: String
+    private var environment: AppStoreEnvironment
+    private var chainVerifier: ChainVerifier
+    private var enableOnlineChecks: Bool
+
+    /// - Parameter rootCertificates: The set of Apple Root certificate authority certificates, as found on [Apple PKI](https://www.apple.com/certificateauthority/)
+    /// - Parameter bundleId: The bundle identifier of the app.
+    /// - Parameter environment: The server environment, either sandbox or production.
+    /// - Parameter enableOnlineChecks: Whether to enable revocation checking and check expiration using the current date
+    /// - Throws: When the root certificates are malformed
+    public init(rootCertificates: [Data], bundleId: String, environment: AppStoreEnvironment, enableOnlineChecks: Bool) throws {
+        self.bundleId = bundleId
+        self.environment = environment
+        self.chainVerifier = try ChainVerifier(rootCertificates: rootCertificates)
+        self.enableOnlineChecks = enableOnlineChecks
+    }
+
+    ///Verifies and decodes an app receipt, as obtained from a device
+    ///See [App Store Receipts](https://developer.apple.com/documentation/appstorereceipts)
+    ///
+    ///- Parameter encodedReceipt The base64-encoded app receipt
+    ///- Returns: If success, the decoded receipt after verification, else the reason for verification failure
+    public func verifyAndDecodeAppReceipt(encodedReceipt: String) async -> VerificationResult<AppReceipt> {
+        // The decoder ignores unknown characters, tolerating the line breaks base64 receipts commonly pick up in transit
+        guard let receiptDer = Data(base64Encoded: encodedReceipt, options: .ignoreUnknownCharacters) else {
+            return VerificationResult.invalid(VerificationError.VERIFICATION_FAILURE)
+        }
+        let signedData: PKCS7SignedData
+        let receipt: AppReceipt
+        do {
+            // BER.parse throws when parsing does not exhaust the input, rejecting trailing bytes after the CMS blob
+            signedData = try PKCS7SignedData(berEncoded: [UInt8](receiptDer))
+            // Parsed before signature verification only to learn the creation date (chain validity is anchored at
+            // signing time); nothing from it is trusted until the chain and signature checks pass.
+            receipt = try AppReceiptVerifier.parseReceiptPayload(signedData.encapsulatedContent)
+        } catch let error as AppReceiptVerificationError {
+            return VerificationResult.invalid(error.verificationError)
+        } catch {
+            return VerificationResult.invalid(VerificationError.VERIFICATION_FAILURE)
+        }
+        if self.environment != .xcode && self.environment != .localTesting {
+            let effectiveDate = self.enableOnlineChecks || receipt.receiptCreationDate == nil ? Date() : receipt.receiptCreationDate!
+            let signerCertificate: Certificate
+            switch await verifyChain(signedData: signedData, effectiveDate: effectiveDate) {
+            case .valid(let certificate):
+                signerCertificate = certificate
+            case .invalid(let error):
+                return VerificationResult.invalid(error)
+            }
+            if let signatureFailure = verifySignature(signedData: signedData, signerCertificate: signerCertificate) {
+                return VerificationResult.invalid(signatureFailure)
+            }
+        }
+        // In the Xcode and LocalTesting environments the data is not signed by the App Store and signature
+        // verification is skipped, but the bundle id and environment are still validated.
+        if self.bundleId != receipt.bundleId {
+            return VerificationResult.invalid(VerificationError.INVALID_APP_IDENTIFIER)
+        }
+        if self.environment != AppReceiptVerifier.environmentForReceiptType(receipt.receiptType) {
+            return VerificationResult.invalid(VerificationError.INVALID_ENVIRONMENT)
+        }
+        return VerificationResult.valid(receipt)
+    }
+
+    ///Verifies an app receipt and extracts a transaction id from its in-app purchases, the validated counterpart of
+    ///``ReceiptUtility/extractTransactionId(appReceipt:)`` with the same output contract: a transaction id from the
+    ///array of in-app purchases, or nil if the receipt contains none.
+    ///
+    ///- Parameter encodedReceipt The base64-encoded app receipt
+    ///- Returns: If success, a transaction id from the receipt's in-app purchases, nil if the receipt contains no
+    ///in-app purchases, else the reason for verification failure
+    public func verifyAndExtractTransactionId(encodedReceipt: String) async -> VerificationResult<String?> {
+        switch await verifyAndDecodeAppReceipt(encodedReceipt: encodedReceipt) {
+        case .valid(let receipt):
+            for purchase in receipt.inAppPurchases {
+                if let transactionId = purchase.transactionId {
+                    return VerificationResult.valid(transactionId)
+                }
+                if let originalTransactionId = purchase.originalTransactionId {
+                    return VerificationResult.valid(originalTransactionId)
+                }
+            }
+            return VerificationResult.valid(nil)
+        case .invalid(let error):
+            return VerificationResult.invalid(error)
+        }
+    }
+
+    ///Orders the receipt's embedded certificates as leaf, intermediate, root and hands the leaf and intermediate to
+    ///the shared ``ChainVerifier``, which enforces the chain length, the WWDR intermediate OID and the receipt-signing
+    ///leaf OID, and validates to the caller-supplied Apple roots. As with JWS signed data, the root of the chain comes
+    ///from the caller, not from the receipt.
+    private func verifyChain(signedData: PKCS7SignedData, effectiveDate: Date) async -> VerificationResult<Certificate> {
+        guard let leaf = signedData.signerCertificate() else {
+            return VerificationResult.invalid(VerificationError.INVALID_CERTIFICATE)
+        }
+        var ordered = [leaf]
+        while ordered.count < signedData.certificates.count {
+            guard let issuer = signedData.certificates.first(where: { candidate in
+                candidate.subject == ordered[ordered.count - 1].issuer && !ordered.contains(candidate)
+            }) else {
+                break
+            }
+            ordered.append(issuer)
+        }
+        guard ordered.count == AppReceiptVerifier.EXPECTED_CHAIN_LENGTH else {
+            return VerificationResult.invalid(VerificationError.VERIFICATION_FAILURE)
+        }
+        let verificationResult = await chainVerifier.verifyChain(leaf: ordered[0], intermediate: ordered[1], online: self.enableOnlineChecks, validationTime: effectiveDate)
+        switch verificationResult {
+        case .validCertificate(_):
+            return VerificationResult.valid(leaf)
+        case .couldNotValidate(let terminalErrors):
+            for failure in terminalErrors {
+                if failure.policyFailureReason.description.contains(Requester.OCSP_NETWORK_REQUEST_FAILED) {
+                    // OCSP validation failed due to network failures
+                    return VerificationResult.invalid(VerificationError.RETRYABLE_VERIFICATION_FAILURE)
+                }
+            }
+            return VerificationResult.invalid(VerificationError.VERIFICATION_FAILURE)
+        }
+    }
+
+    ///Verifies the CMS signature made by the signer certificate. The signature is made over the signed attributes when
+    ///they are present, in which case the message digest attribute must match the digest of the encapsulated payload,
+    ///and over the payload itself otherwise. A signer key that is not RSA can satisfy neither, as only RSA signature
+    ///algorithms are ever offered to it.
+    private func verifySignature(signedData: PKCS7SignedData, signerCertificate: Certificate) -> VerificationError? {
+        let signatureAlgorithm: Certificate.SignatureAlgorithm
+        switch signedData.digestAlgorithm {
+        case PKCS7SignedData.SHA1_OID:
+            signatureAlgorithm = .sha1WithRSAEncryption
+        case PKCS7SignedData.SHA256_OID:
+            signatureAlgorithm = .sha256WithRSAEncryption
+        default:
+            // Unrecognized receipt digest algorithm
+            return VerificationError.VERIFICATION_FAILURE
+        }
+        var signedBytes = signedData.encapsulatedContent
+        if let signedAttributes = signedData.signedAttributes {
+            let contentDigest: [UInt8] = signatureAlgorithm == .sha1WithRSAEncryption
+                ? Array(Insecure.SHA1.hash(data: signedData.encapsulatedContent))
+                : Array(SHA256.hash(data: signedData.encapsulatedContent))
+            guard let messageDigest = signedData.messageDigest, messageDigest == contentDigest else {
+                return VerificationError.VERIFICATION_FAILURE
+            }
+            signedBytes = signedAttributes
+        }
+        guard signerCertificate.publicKey.isValidSignature(signedData.signature, for: signedBytes, signatureAlgorithm: signatureAlgorithm) else {
+            return VerificationError.VERIFICATION_FAILURE
+        }
+        return nil
+    }
+
+    ///Maps the receipt-type attribute to a server environment. Only explicit production values map to
+    ///``AppStoreEnvironment/production``; unknown or missing values map to nil and fail environment validation.
+    private static func environmentForReceiptType(_ receiptType: String?) -> AppStoreEnvironment? {
+        switch receiptType {
+        case "Production", "ProductionVPP":
+            return .production
+        case "ProductionSandbox", "ProductionVPPSandbox":
+            return .sandbox
+        case "Xcode":
+            return .xcode
+        case "LocalTesting":
+            return .localTesting
+        default:
+            return nil
+        }
+    }
+
+    private static func parseReceiptPayload(_ payload: [UInt8]) throws -> AppReceipt {
+        var receipt = AppReceipt()
+        for attribute in try parseAttributeSet(payload) {
+            switch attribute.type {
+            case ATTR_RECEIPT_TYPE:
+                receipt.receiptType = try decodeString(attribute.value)
+            case ATTR_BUNDLE_ID:
+                receipt.bundleId = try decodeString(attribute.value)
+                receipt.bundleIdBytes = Data(attribute.value)
+            case ATTR_APP_VERSION:
+                receipt.applicationVersion = try decodeString(attribute.value)
+            case ATTR_OPAQUE_VALUE:
+                receipt.opaqueValue = Data(attribute.value)
+            case ATTR_SHA1_HASH:
+                receipt.sha1Hash = Data(attribute.value)
+            case ATTR_CREATION_DATE:
+                receipt.receiptCreationDate = try decodeDate(attribute.value)
+            case ATTR_IN_APP:
+                receipt.inAppPurchases.append(try parseInAppPurchase(attribute.value))
+            case ATTR_ORIGINAL_PURCHASE_DATE:
+                receipt.originalPurchaseDate = try decodeDate(attribute.value)
+            case ATTR_ORIGINAL_APP_VERSION:
+                receipt.originalApplicationVersion = try decodeString(attribute.value)
+            case ATTR_EXPIRATION_DATE:
+                receipt.expirationDate = try decodeDate(attribute.value)
+            default:
+                receipt.unknownAttributes[attribute.type, default: []].append(Data(attribute.value))
+            }
+        }
+        return receipt
+    }
+
+    private static func parseInAppPurchase(_ inAppSet: [UInt8]) throws -> InAppPurchaseReceipt {
+        var purchase = InAppPurchaseReceipt()
+        for attribute in try parseAttributeSet(inAppSet) {
+            switch attribute.type {
+            case IAP_QUANTITY:
+                purchase.quantity = try decodeInteger(attribute.value)
+            case IAP_PRODUCT_ID:
+                purchase.productId = try decodeString(attribute.value)
+            case IAP_TRANSACTION_ID:
+                purchase.transactionId = try decodeString(attribute.value)
+            case IAP_PURCHASE_DATE:
+                purchase.purchaseDate = try decodeDate(attribute.value)
+            case IAP_ORIGINAL_TRANSACTION_ID:
+                purchase.originalTransactionId = try decodeString(attribute.value)
+            case IAP_ORIGINAL_PURCHASE_DATE:
+                purchase.originalPurchaseDate = try decodeDate(attribute.value)
+            case IAP_EXPIRES_DATE:
+                purchase.expiresDate = try decodeDate(attribute.value)
+            case IAP_WEB_ORDER_LINE_ITEM_ID:
+                purchase.webOrderLineItemId = try decodeInteger(attribute.value)
+            case IAP_CANCELLATION_DATE:
+                purchase.cancellationDate = try decodeDate(attribute.value)
+            case IAP_IS_IN_INTRO_OFFER_PERIOD:
+                purchase.isInIntroOfferPeriod = try decodeInteger(attribute.value) != 0
+            default:
+                purchase.unknownAttributes[attribute.type, default: []].append(Data(attribute.value))
+            }
+        }
+        return purchase
+    }
+
+    ///`ReceiptAttribute ::= SEQUENCE { type INTEGER, version INTEGER, value OCTET STRING }`
+    private struct ReceiptAttribute {
+        let type: Int64
+        let value: [UInt8]
+    }
+
+    private static func parseAttributeSet(_ der: [UInt8]) throws -> [ReceiptAttribute] {
+        var parsed: ASN1Node
+        do {
+            parsed = try BER.parse(der)
+            if parsed.identifier == .octetString {
+                // Xcode receipts double-wrap the payload in an extra OCTET STRING; ReceiptUtility handles the same shape.
+                parsed = try BER.parse(try ASN1OctetString(berEncoded: parsed).bytes)
+            }
+        } catch {
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        guard parsed.identifier == .set, case .constructed(let elements) = parsed.content else {
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        var attributes: [ReceiptAttribute] = []
+        for element in elements {
+            attributes.append(try parseAttribute(element))
+        }
+        return attributes
+    }
+
+    private static func parseAttribute(_ element: ASN1Node) throws -> ReceiptAttribute {
+        do {
+            return try BER.sequence(element, identifier: .sequence) { nodes in
+                guard let typeNode = nodes.next(), nodes.next() != nil, let valueNode = nodes.next() else {
+                    throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+                }
+                while nodes.next() != nil {}
+                let type = try boundedInt64(typeNode)
+                let value = try ASN1OctetString(berEncoded: valueNode)
+                return ReceiptAttribute(type: type, value: Array(value.bytes))
+            }
+        } catch let error as AppReceiptVerificationError {
+            throw error
+        } catch {
+            // Malformed receipt attribute
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+    }
+
+    ///Non-negative and within Int64 range, real receipts carry 7-byte integers.
+    private static func boundedInt64(_ node: ASN1Node) throws -> Int64 {
+        guard let value = try? Int64(berEncoded: node, withIdentifier: .integer), value >= 0 else {
+            // Receipt integer out of range
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        return value
+    }
+
+    private static func decodeString(_ der: [UInt8]) throws -> String {
+        guard let parsed = try? BER.parse(der) else {
+            // Attribute value is not valid ASN.1
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        // Apple is not consistent about which string type an attribute uses
+        let bytes: ArraySlice<UInt8>
+        switch parsed.identifier {
+        case .utf8String:
+            bytes = try ASN1UTF8String(berEncoded: parsed).bytes
+        case .ia5String:
+            bytes = try ASN1IA5String(berEncoded: parsed).bytes
+        case .printableString:
+            bytes = try ASN1PrintableString(berEncoded: parsed).bytes
+        default:
+            // Attribute value is not an ASN.1 string
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        guard let string = String(bytes: bytes, encoding: .utf8) else {
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        return string
+    }
+
+    private static func decodeInteger(_ der: [UInt8]) throws -> Int64 {
+        guard let parsed = try? BER.parse(der), parsed.identifier == .integer else {
+            // Attribute value is not an ASN.1 integer
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        return try boundedInt64(parsed)
+    }
+
+    ///RFC 3339 date in an IA5String; an empty string means absent, which real receipts do.
+    private static func decodeDate(_ der: [UInt8]) throws -> Date? {
+        let text = try decodeString(der)
+        if text.isEmpty {
+            return nil
+        }
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+        if let date = formatter.date(from: text) {
+            return date
+        }
+        formatter.formatOptions = [.withInternetDateTime]
+        guard let date = formatter.date(from: text) else {
+            // Unparseable receipt date
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        return date
+    }
+}
+
+///Carries the ``VerificationError`` a failed decoding step should be reported as, so the ASN.1 walk can fail fast
+///without every helper returning a result.
+internal struct AppReceiptVerificationError: Error {
+    let verificationError: VerificationError
+
+    init(_ verificationError: VerificationError) {
+        self.verificationError = verificationError
+    }
+}
+
+///The subset of a PKCS#7 `SignedData` an app receipt needs. Parsed with BER because genuine App Store and
+///Xcode-generated receipts use indefinite lengths and segmented OCTET STRINGs.
+///```
+///ContentInfo ::= SEQUENCE { contentType OBJECT IDENTIFIER, content [0] EXPLICIT SignedData }
+///SignedData ::= SEQUENCE { version INTEGER, digestAlgorithms SET OF AlgorithmIdentifier,
+///                          encapContentInfo EncapsulatedContentInfo, certificates [0] IMPLICIT CertificateSet OPTIONAL,
+///                          crls [1] IMPLICIT RevocationInfoChoices OPTIONAL, signerInfos SET OF SignerInfo }
+///SignerInfo ::= SEQUENCE { version INTEGER, sid SignerIdentifier, digestAlgorithm AlgorithmIdentifier,
+///                          signedAttrs [0] IMPLICIT SignedAttributes OPTIONAL, signatureAlgorithm AlgorithmIdentifier,
+///                          signature OCTET STRING, unsignedAttrs [1] IMPLICIT UnsignedAttributes OPTIONAL }
+///```
+internal struct PKCS7SignedData {
+
+    static let SIGNED_DATA_OID: ASN1ObjectIdentifier = [1, 2, 840, 113549, 1, 7, 2]
+    static let MESSAGE_DIGEST_OID: ASN1ObjectIdentifier = [1, 2, 840, 113549, 1, 9, 4]
+    static let SHA1_OID: ASN1ObjectIdentifier = [1, 3, 14, 3, 2, 26]
+    static let SHA256_OID: ASN1ObjectIdentifier = [2, 16, 840, 1, 101, 3, 4, 2, 1]
+
+    private static let CONTEXT_TAG_0 = ASN1Identifier(tagWithNumber: 0, tagClass: .contextSpecific)
+    private static let CONTEXT_TAG_1 = ASN1Identifier(tagWithNumber: 1, tagClass: .contextSpecific)
+
+    ///The encapsulated payload of the container, the receipt's attribute set.
+    let encapsulatedContent: [UInt8]
+    ///The certificates embedded in the container, in the order they appear.
+    let certificates: [Certificate]
+    ///The digest algorithm of the first signer info, which also selects the RSA signature algorithm.
+    let digestAlgorithm: ASN1ObjectIdentifier
+    ///The bytes the signature covers when signed attributes are present: the `[0] IMPLICIT` signed attributes
+    ///re-tagged as an explicit SET OF, as RFC 5652 section 5.4 requires.
+    let signedAttributes: [UInt8]?
+    ///The message digest signed attribute, which must match the digest of ``encapsulatedContent``.
+    let messageDigest: [UInt8]?
+    let signature: [UInt8]
+
+    private let signerIssuer: DistinguishedName
+    private let signerSerialNumber: [UInt8]
+
+    init(berEncoded bytes: [UInt8]) throws {
+        let contentInfo = try PKCS7SignedData.children(try BER.parse(bytes))
+        guard contentInfo.count >= 2,
+              let contentType = try? ASN1ObjectIdentifier(berEncoded: contentInfo[0]),
+              contentType == PKCS7SignedData.SIGNED_DATA_OID else {
+            // Receipt is not a PKCS#7 container
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        let signedData = try PKCS7SignedData.children(try PKCS7SignedData.explicit(contentInfo[1]))
+        guard signedData.count >= 4 else {
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        // encapContentInfo ::= SEQUENCE { eContentType OBJECT IDENTIFIER, eContent [0] EXPLICIT OCTET STRING OPTIONAL }
+        let encapContentInfo = try PKCS7SignedData.children(signedData[2])
+        guard encapContentInfo.count >= 2 else {
+            // Receipt has no encapsulated payload
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        self.encapsulatedContent = try PKCS7SignedData.octetStringValue(try PKCS7SignedData.explicit(encapContentInfo[1]))
+
+        var certificates: [Certificate] = []
+        for node in signedData.dropFirst(3) where node.identifier == PKCS7SignedData.CONTEXT_TAG_0 {
+            for certificateNode in try PKCS7SignedData.children(node) {
+                guard let certificate = try? Certificate(derEncoded: certificateNode) else {
+                    throw AppReceiptVerificationError(.INVALID_CERTIFICATE)
+                }
+                certificates.append(certificate)
+            }
+        }
+        self.certificates = certificates
+
+        guard let signerInfos = signedData.last, signerInfos.identifier == .set,
+              let signerInfo = try PKCS7SignedData.children(signerInfos).first else {
+            // Receipt has no signer info
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        let signerFields = try PKCS7SignedData.children(signerInfo)
+        guard signerFields.count >= 5 else {
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        // sid ::= IssuerAndSerialNumber SEQUENCE { issuer Name, serialNumber INTEGER }; the subjectKeyIdentifier
+        // choice is not used by App Store receipts.
+        let signerIdentifier = try PKCS7SignedData.children(signerFields[1])
+        guard signerIdentifier.count >= 2, let issuer = try? DistinguishedName(derEncoded: signerIdentifier[0]) else {
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        self.signerIssuer = issuer
+        self.signerSerialNumber = PKCS7SignedData.normalizedSerialNumber(try PKCS7SignedData.primitive(signerIdentifier[1]))
+
+        let digestAlgorithmFields = try PKCS7SignedData.children(signerFields[2])
+        guard digestAlgorithmFields.count >= 1, let digestAlgorithm = try? ASN1ObjectIdentifier(berEncoded: digestAlgorithmFields[0]) else {
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        self.digestAlgorithm = digestAlgorithm
+
+        var index = 3
+        if signerFields[index].identifier == PKCS7SignedData.CONTEXT_TAG_0 {
+            let signedAttributesNode = signerFields[index]
+            // The signature covers the signed attributes re-encoded as an explicit SET (RFC 5652 section 5.4): the
+            // IMPLICIT [0] tag byte is swapped for the SET tag, leaving the length and contents untouched.
+            var reencoded = Array(signedAttributesNode.encodedBytes)
+            guard !reencoded.isEmpty else {
+                throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+            }
+            reencoded[0] = 0x31
+            self.signedAttributes = reencoded
+            var messageDigest: [UInt8]? = nil
+            for attribute in try PKCS7SignedData.children(signedAttributesNode) {
+                let attributeFields = try PKCS7SignedData.children(attribute)
+                guard attributeFields.count >= 2 else {
+                    throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+                }
+                if (try? ASN1ObjectIdentifier(berEncoded: attributeFields[0])) == PKCS7SignedData.MESSAGE_DIGEST_OID,
+                   let value = try PKCS7SignedData.children(attributeFields[1]).first {
+                    messageDigest = try PKCS7SignedData.octetStringValue(value)
+                }
+            }
+            self.messageDigest = messageDigest
+            index += 1
+        } else {
+            // Genuine App Store receipts carry no signed attributes; the signature then covers the payload directly
+            self.signedAttributes = nil
+            self.messageDigest = nil
+        }
+        // The signature algorithm identifier is deliberately not read: genuine receipts declare a bare rsaEncryption
+        // there, and the digest algorithm above is what selects the hash. Only RSA algorithms are ever offered to the
+        // signer key, so a non-RSA key can never produce a valid signature.
+        index += 1
+        guard index < signerFields.count else {
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        self.signature = try PKCS7SignedData.octetStringValue(signerFields[index])
+    }
+
+    ///The embedded certificate the first signer info identifies, if it is present in the container.
+    func signerCertificate() -> Certificate? {
+        return certificates.first { certificate in
+            certificate.issuer == signerIssuer
+                && PKCS7SignedData.normalizedSerialNumber(Array(certificate.serialNumber.bytes)) == signerSerialNumber
+        }
+    }
+
+    ///Bounds-checked navigation. A plain array subscript traps uncatchably, and every structure here is
+    ///attacker-controlled until the signature has been verified.
+    private static func children(_ node: ASN1Node) throws -> [ASN1Node] {
+        guard case .constructed(let nodes) = node.content else {
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        return Array(nodes)
+    }
+
+    ///Unwraps an EXPLICIT context tag to the single node it contains.
+    private static func explicit(_ node: ASN1Node) throws -> ASN1Node {
+        let inner = try children(node)
+        guard inner.count == 1 else {
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        return inner[0]
+    }
+
+    private static func primitive(_ node: ASN1Node) throws -> [UInt8] {
+        guard case .primitive(let bytes) = node.content else {
+            throw AppReceiptVerificationError(.VERIFICATION_FAILURE)
+        }
+        return Array(bytes)
+    }
+
+    ///The value bytes of an OCTET STRING, joining the chunks of a BER constructed encoding.
+    private static func octetStringValue(_ node: ASN1Node) throws -> [UInt8] {
+        switch node.content {
+        case .primitive(let bytes):
+            return Array(bytes)
+        case .constructed(let chunks):
+            var value: [UInt8] = []
+            for chunk in chunks {
+                value.append(contentsOf: try octetStringValue(chunk))
+            }
+            return value
+        }
+    }
+
+    ///Drops the leading zero a positive INTEGER carries to stay unsigned, so serial numbers compare by value.
+    private static func normalizedSerialNumber(_ bytes: [UInt8]) -> [UInt8] {
+        return Array(bytes.drop(while: { $0 == 0x00 }))
+    }
+}

--- a/Sources/AppStoreServerLibrary/Models/AppReceipt.swift
+++ b/Sources/AppStoreServerLibrary/Models/AppReceipt.swift
@@ -1,0 +1,62 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import Foundation
+
+///A decoded legacy App Store receipt (the PKCS#7 app receipt).
+///
+///[receipt](https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt)
+public struct AppReceipt: Hashable, Sendable {
+
+    public init(receiptType: String? = nil, bundleId: String? = nil, bundleIdBytes: Data? = nil, applicationVersion: String? = nil, opaqueValue: Data? = nil, sha1Hash: Data? = nil, receiptCreationDate: Date? = nil, originalPurchaseDate: Date? = nil, originalApplicationVersion: String? = nil, expirationDate: Date? = nil, inAppPurchases: [InAppPurchaseReceipt] = [], unknownAttributes: [Int64: [Data]] = [:]) {
+        self.receiptType = receiptType
+        self.bundleId = bundleId
+        self.bundleIdBytes = bundleIdBytes
+        self.applicationVersion = applicationVersion
+        self.opaqueValue = opaqueValue
+        self.sha1Hash = sha1Hash
+        self.receiptCreationDate = receiptCreationDate
+        self.originalPurchaseDate = originalPurchaseDate
+        self.originalApplicationVersion = originalApplicationVersion
+        self.expirationDate = expirationDate
+        self.inAppPurchases = inAppPurchases
+        self.unknownAttributes = unknownAttributes
+    }
+
+    ///The raw receipt type, e.g. `Production`, `ProductionVPP`, `ProductionSandbox`, `ProductionVPPSandbox` or `Xcode`.
+    public var receiptType: String?
+
+    ///The bundle identifier of the app the receipt belongs to.
+    public var bundleId: String?
+
+    ///The raw ASN.1 bytes of the bundle identifier attribute, needed together with ``opaqueValue`` and ``sha1Hash``
+    ///to compute the device-hash binding described in Apple's receipt validation guide.
+    public var bundleIdBytes: Data?
+
+    ///The app's version number.
+    public var applicationVersion: String?
+
+    ///An opaque value used, with other data, to compute the device hash.
+    public var opaqueValue: Data?
+
+    ///The SHA-1 device-hash attribute of the receipt.
+    public var sha1Hash: Data?
+
+    ///The time the App Store generated the receipt.
+    public var receiptCreationDate: Date?
+
+    ///The time of the original app purchase.
+    public var originalPurchaseDate: Date?
+
+    ///The version of the app that the user originally purchased.
+    public var originalApplicationVersion: String?
+
+    ///The expiration date of the receipt. Present for apps purchased through the Volume Purchase Program.
+    public var expirationDate: Date?
+
+    ///The decoded in-app purchase attributes contained in the receipt.
+    public var inAppPurchases: [InAppPurchaseReceipt]
+
+    ///Attribute types this library does not model, keyed by type, with the verified-but-undecoded value bytes,
+    ///so fields Apple adds later remain accessible without a library update.
+    public var unknownAttributes: [Int64: [Data]]
+}

--- a/Sources/AppStoreServerLibrary/Models/InAppPurchaseReceipt.swift
+++ b/Sources/AppStoreServerLibrary/Models/InAppPurchaseReceipt.swift
@@ -1,0 +1,57 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import Foundation
+
+///A decoded in-app purchase attribute from a legacy App Store receipt.
+///
+///[in_app](https://developer.apple.com/documentation/appstorereceipts/responsebody/receipt/in_app)
+public struct InAppPurchaseReceipt: Hashable, Sendable {
+
+    public init(quantity: Int64? = nil, productId: String? = nil, transactionId: String? = nil, originalTransactionId: String? = nil, purchaseDate: Date? = nil, originalPurchaseDate: Date? = nil, expiresDate: Date? = nil, cancellationDate: Date? = nil, webOrderLineItemId: Int64? = nil, isInIntroOfferPeriod: Bool? = nil, unknownAttributes: [Int64: [Data]] = [:]) {
+        self.quantity = quantity
+        self.productId = productId
+        self.transactionId = transactionId
+        self.originalTransactionId = originalTransactionId
+        self.purchaseDate = purchaseDate
+        self.originalPurchaseDate = originalPurchaseDate
+        self.expiresDate = expiresDate
+        self.cancellationDate = cancellationDate
+        self.webOrderLineItemId = webOrderLineItemId
+        self.isInIntroOfferPeriod = isInIntroOfferPeriod
+        self.unknownAttributes = unknownAttributes
+    }
+
+    ///The number of items purchased.
+    public var quantity: Int64?
+
+    ///The unique identifier of the product purchased.
+    public var productId: String?
+
+    ///The unique identifier of the transaction.
+    public var transactionId: String?
+
+    ///The unique identifier of the original transaction.
+    public var originalTransactionId: String?
+
+    ///The time of the purchase.
+    public var purchaseDate: Date?
+
+    ///The time of the original purchase.
+    public var originalPurchaseDate: Date?
+
+    ///The expiration time of the subscription.
+    public var expiresDate: Date?
+
+    ///The time Apple customer support canceled the transaction or the subscription was upgraded.
+    public var cancellationDate: Date?
+
+    ///The unique identifier of subscription purchase events across devices, including subscription renewals.
+    public var webOrderLineItemId: Int64?
+
+    ///Whether the subscription is in an introductory offer period.
+    public var isInIntroOfferPeriod: Bool?
+
+    ///Attribute types this library does not model, keyed by type, with the verified-but-undecoded value bytes,
+    ///so fields Apple adds later remain accessible without a library update.
+    public var unknownAttributes: [Int64: [Data]]
+}

--- a/Sources/AppStoreServerLibrary/ReceiptUtility.swift
+++ b/Sources/AppStoreServerLibrary/ReceiptUtility.swift
@@ -11,6 +11,7 @@ public class ReceiptUtility {
     
     ///Extracts a transaction id from an encoded App Receipt. Throws if the receipt does not match the expected format.
     ///*NO validation* is performed on the receipt, and any data returned should only be used to call the App Store Server API.
+    ///To verify the receipt's signature before extraction, use ``AppReceiptVerifier/verifyAndExtractTransactionId(encodedReceipt:)``.
     ///- Parameter appReceipt The unmodified app receipt
     ///- Returns A transaction id from the array of in-app purchases, null if the receipt contains no in-app purchases
     public static func extractTransactionId(appReceipt: String) -> String? {

--- a/Tests/AppStoreServerLibraryTests/AppReceiptVerifierTests.swift
+++ b/Tests/AppStoreServerLibraryTests/AppReceiptVerifierTests.swift
@@ -1,0 +1,379 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import XCTest
+@testable import AppStoreServerLibrary
+
+import SwiftASN1
+
+final class AppReceiptVerifierTests: XCTestCase {
+
+    private static let BUNDLE_ID = "com.example"
+    private static let APP_VERSION = "1.2.3"
+    private static let ORIGINAL_APP_VERSION = "1.0"
+    private static let OPAQUE_VALUE: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8]
+    private static let SHA1_HASH: [UInt8] = [
+        0xa1, 0xb2, 0xc3, 0xd4, 0xe5, 0xf6, 0x07, 0x18,
+        0x29, 0x3a, 0x4b, 0x5c, 0x6d, 0x7e, 0x8f, 0x90, 0x11, 0x22, 0x33, 0x44]
+    private static let UNKNOWN_RECEIPT_ATTRIBUTE_VALUE: [UInt8] = [0x0d, 0x0e, 0x0a, 0x0d]
+    private static let UNKNOWN_IN_APP_ATTRIBUTE_VALUE: [UInt8] = [0x0b, 0x0e, 0x0e, 0x0f]
+
+    private static let RECEIPT_CREATION_DATE = "2024-03-01T12:00:00Z"
+    private static let RECEIPT_CREATION_DATE_VALUE = Date(timeIntervalSince1970: 1709294400)
+    private static let ORIGINAL_PURCHASE_DATE = "2023-11-15T08:30:00Z"
+    private static let ORIGINAL_PURCHASE_DATE_VALUE = Date(timeIntervalSince1970: 1700037000)
+    private static let EXPIRATION_DATE = "2030-01-01T00:00:00Z"
+    private static let EXPIRATION_DATE_VALUE = Date(timeIntervalSince1970: 1893456000)
+
+    private static let CONSUMABLE_PRODUCT_ID = "com.example.coins"
+    private static let CONSUMABLE_PURCHASE_DATE = "2024-01-15T12:00:00Z"
+    private static let CONSUMABLE_PURCHASE_DATE_VALUE = Date(timeIntervalSince1970: 1705320000)
+    private static let CONSUMABLE_ORIGINAL_PURCHASE_DATE = "2024-01-10T09:00:00Z"
+    private static let CONSUMABLE_ORIGINAL_PURCHASE_DATE_VALUE = Date(timeIntervalSince1970: 1704877200)
+
+    private static let SUBSCRIPTION_PRODUCT_ID = "com.example.subscription"
+    private static let SUBSCRIPTION_PURCHASE_DATE = "2024-02-01T09:30:00Z"
+    private static let SUBSCRIPTION_PURCHASE_DATE_VALUE = Date(timeIntervalSince1970: 1706779800)
+    private static let SUBSCRIPTION_EXPIRES_DATE = "2030-02-01T09:30:00Z"
+    private static let SUBSCRIPTION_EXPIRES_DATE_VALUE = Date(timeIntervalSince1970: 1896168600)
+    private static let SUBSCRIPTION_CANCELLATION_DATE = "2024-06-01T00:00:00Z"
+    private static let SUBSCRIPTION_CANCELLATION_DATE_VALUE = Date(timeIntervalSince1970: 1717200000)
+
+    private static let receiptCreator = try! ReceiptCreator.createReceiptCreator()
+    private static let sandboxReceipt = try! receiptCreator.signReceipt(receiptPayload("ProductionSandbox", BUNDLE_ID, RECEIPT_CREATION_DATE))
+    private static let xcodeReceiptCreator = try! ReceiptCreator.createSelfSignedReceiptCreator()
+
+    public func testAppReceiptDecoding() async throws {
+        let receipt = try await validReceipt(AppReceiptVerifierTests.verifier(environment: .sandbox).verifyAndDecodeAppReceipt(encodedReceipt: encode(AppReceiptVerifierTests.sandboxReceipt)))
+
+        XCTAssertEqual("ProductionSandbox", receipt.receiptType)
+        XCTAssertEqual(AppReceiptVerifierTests.BUNDLE_ID, receipt.bundleId)
+        XCTAssertEqual(derEncodedUTF8String(AppReceiptVerifierTests.BUNDLE_ID), receipt.bundleIdBytes)
+        XCTAssertEqual(AppReceiptVerifierTests.APP_VERSION, receipt.applicationVersion)
+        XCTAssertEqual(AppReceiptVerifierTests.ORIGINAL_APP_VERSION, receipt.originalApplicationVersion)
+        XCTAssertEqual(Data(AppReceiptVerifierTests.OPAQUE_VALUE), receipt.opaqueValue)
+        XCTAssertEqual(Data(AppReceiptVerifierTests.SHA1_HASH), receipt.sha1Hash)
+        XCTAssertEqual(AppReceiptVerifierTests.RECEIPT_CREATION_DATE_VALUE, receipt.receiptCreationDate)
+        XCTAssertEqual(AppReceiptVerifierTests.ORIGINAL_PURCHASE_DATE_VALUE, receipt.originalPurchaseDate)
+        XCTAssertEqual(AppReceiptVerifierTests.EXPIRATION_DATE_VALUE, receipt.expirationDate)
+        XCTAssertEqual(2, receipt.inAppPurchases.count)
+
+        let consumable = receipt.inAppPurchases[0]
+        XCTAssertEqual(1, consumable.quantity)
+        XCTAssertEqual(AppReceiptVerifierTests.CONSUMABLE_PRODUCT_ID, consumable.productId)
+        XCTAssertEqual("70000000000001", consumable.transactionId)
+        XCTAssertEqual("70000000000001", consumable.originalTransactionId)
+        XCTAssertEqual(AppReceiptVerifierTests.CONSUMABLE_PURCHASE_DATE_VALUE, consumable.purchaseDate)
+        XCTAssertEqual(AppReceiptVerifierTests.CONSUMABLE_ORIGINAL_PURCHASE_DATE_VALUE, consumable.originalPurchaseDate)
+        XCTAssertEqual(42, consumable.webOrderLineItemId)
+
+        let subscription = receipt.inAppPurchases[1]
+        XCTAssertEqual(1, subscription.quantity)
+        XCTAssertEqual(AppReceiptVerifierTests.SUBSCRIPTION_PRODUCT_ID, subscription.productId)
+        XCTAssertEqual("70000000000002", subscription.transactionId)
+        XCTAssertEqual("70000000000002", subscription.originalTransactionId)
+        XCTAssertEqual(AppReceiptVerifierTests.SUBSCRIPTION_PURCHASE_DATE_VALUE, subscription.purchaseDate)
+        XCTAssertEqual(AppReceiptVerifierTests.SUBSCRIPTION_PURCHASE_DATE_VALUE, subscription.originalPurchaseDate)
+        XCTAssertEqual(AppReceiptVerifierTests.SUBSCRIPTION_EXPIRES_DATE_VALUE, subscription.expiresDate)
+        XCTAssertEqual(AppReceiptVerifierTests.SUBSCRIPTION_CANCELLATION_DATE_VALUE, subscription.cancellationDate)
+        XCTAssertEqual(12345, subscription.webOrderLineItemId)
+    }
+
+    ///An in-app purchase attribute that is present but empty means "absent", and the intro offer flag is an integer
+    ///that must surface as a boolean, so a caller can distinguish "no expiration" from "expired at epoch".
+    public func testInAppPurchaseFlagAndEmptyDateDecoding() async throws {
+        let receipt = try await validReceipt(AppReceiptVerifierTests.verifier(environment: .sandbox).verifyAndDecodeAppReceipt(encodedReceipt: encode(AppReceiptVerifierTests.sandboxReceipt)))
+
+        let consumable = receipt.inAppPurchases[0]
+        XCTAssertEqual(false, consumable.isInIntroOfferPeriod)
+        XCTAssertNil(consumable.expiresDate)
+        XCTAssertNil(consumable.cancellationDate)
+
+        XCTAssertEqual(true, receipt.inAppPurchases[1].isInIntroOfferPeriod)
+    }
+
+    ///Attribute types this library does not model must survive decoding with their raw bytes, so a receipt field
+    ///Apple adds later stays reachable.
+    public func testUnknownAttributesArePreserved() async throws {
+        let receipt = try await validReceipt(AppReceiptVerifierTests.verifier(environment: .sandbox).verifyAndDecodeAppReceipt(encodedReceipt: encode(AppReceiptVerifierTests.sandboxReceipt)))
+
+        XCTAssertEqual(1, receipt.unknownAttributes[9999]?.count)
+        XCTAssertEqual(Data(AppReceiptVerifierTests.UNKNOWN_RECEIPT_ATTRIBUTE_VALUE), receipt.unknownAttributes[9999]?[0])
+        XCTAssertEqual(Data(AppReceiptVerifierTests.UNKNOWN_IN_APP_ATTRIBUTE_VALUE), receipt.inAppPurchases[0].unknownAttributes[1799]?[0])
+    }
+
+    public func testWrongBundleId() async throws {
+        let verifier = AppReceiptVerifierTests.verifier(environment: .sandbox, bundleId: "com.example.other")
+        await assertInvalid(.INVALID_APP_IDENTIFIER, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(AppReceiptVerifierTests.sandboxReceipt)))
+    }
+
+    public func testWrongEnvironment() async throws {
+        let productionReceipt = try AppReceiptVerifierTests.receiptCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("Production", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE))
+        let verifier = AppReceiptVerifierTests.verifier(environment: .sandbox)
+        await assertInvalid(.INVALID_ENVIRONMENT, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(productionReceipt)))
+    }
+
+    ///A receipt type this library does not recognize maps to no environment at all rather than defaulting to the
+    ///verifier's, so an unexpected value can never be mistaken for a match.
+    public func testUnknownReceiptType() async throws {
+        let unknownTypeReceipt = try AppReceiptVerifierTests.receiptCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("ProductionInternal", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE))
+        let verifier = AppReceiptVerifierTests.verifier(environment: .sandbox)
+        await assertInvalid(.INVALID_ENVIRONMENT, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(unknownTypeReceipt)))
+    }
+
+    public func testTamperedPayload() async throws {
+        var tamperedReceipt = AppReceiptVerifierTests.sandboxReceipt
+        // Flip a bit inside the app version of the encapsulated payload; the chain is untouched, so only the
+        // signature check can catch this.
+        tamperedReceipt[try indexOf(tamperedReceipt, Array(AppReceiptVerifierTests.APP_VERSION.utf8))] ^= 0x01
+        let verifier = AppReceiptVerifierTests.verifier(environment: .sandbox)
+        await assertInvalid(.VERIFICATION_FAILURE, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(tamperedReceipt)))
+    }
+
+    public func testReceiptSignedByForeignRoot() async throws {
+        let foreignCreator = try ReceiptCreator.createReceiptCreator()
+        let forgedReceipt = try foreignCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("ProductionSandbox", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE))
+        let verifier = AppReceiptVerifierTests.verifier(environment: .sandbox)
+        await assertInvalid(.VERIFICATION_FAILURE, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(forgedReceipt)))
+    }
+
+    public func testLeafWithoutReceiptSigningOid() async throws {
+        let creator = try ReceiptCreator.createReceiptCreator(receiptSignerOid: false)
+        let receipt = try creator.signReceipt(AppReceiptVerifierTests.receiptPayload("ProductionSandbox", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE))
+        let verifier = AppReceiptVerifierTests.verifier(creator, environment: .sandbox)
+        await assertInvalid(.VERIFICATION_FAILURE, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+    }
+
+    public func testIntermediateWithoutWwdrOid() async throws {
+        let creator = try ReceiptCreator.createReceiptCreator(wwdrIntermediateOid: false)
+        let receipt = try creator.signReceipt(AppReceiptVerifierTests.receiptPayload("ProductionSandbox", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE))
+        let verifier = AppReceiptVerifierTests.verifier(creator, environment: .sandbox)
+        await assertInvalid(.VERIFICATION_FAILURE, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+    }
+
+    public func testReceiptWithoutRootCertificateEmbedded() async throws {
+        let receipt = try AppReceiptVerifierTests.receiptCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("ProductionSandbox", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE), embeddedCertificates: 2)
+        let verifier = AppReceiptVerifierTests.verifier(environment: .sandbox)
+        await assertInvalid(.VERIFICATION_FAILURE, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+    }
+
+    public func testReceiptThatIsNotBase64() async throws {
+        let verifier = AppReceiptVerifierTests.verifier(environment: .sandbox)
+        await assertInvalid(.VERIFICATION_FAILURE, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: "!!!not-base64!!!"))
+    }
+
+    public func testReceiptThatIsNotAPkcs7Container() async throws {
+        let verifier = AppReceiptVerifierTests.verifier(environment: .sandbox)
+        await assertInvalid(.VERIFICATION_FAILURE, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(Data([1, 2, 3, 4]))))
+    }
+
+    ///Bytes appended after the container must not be ignored, a verifier that parsed a prefix would accept a receipt
+    ///carrying unverified extra data.
+    public func testTrailingBytesAfterContainer() async throws {
+        let paddedReceipt = AppReceiptVerifierTests.sandboxReceipt + Data([0, 0, 0, 0])
+        let verifier = AppReceiptVerifierTests.verifier(environment: .sandbox)
+        await assertInvalid(.VERIFICATION_FAILURE, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(paddedReceipt)))
+    }
+
+    ///Receipts outlive the certificates that signed them, so with online checks off the chain is evaluated at the
+    ///receipt's creation date.
+    public func testReceiptSignedByNowExpiredCertificates() async throws {
+        let expiredCreator = try ReceiptCreator.createReceiptCreator(notBefore: ReceiptCreator.daysAgo(730), notAfter: ReceiptCreator.daysAgo(365))
+        let createdAt = ReceiptCreator.daysAgo(547)
+        let receipt = try expiredCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("ProductionSandbox", AppReceiptVerifierTests.BUNDLE_ID, rfc3339(createdAt)), signingTime: createdAt)
+
+        let decoded = try await validReceipt(AppReceiptVerifierTests.verifier(expiredCreator, environment: .sandbox).verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+        XCTAssertEqual(rfc3339(createdAt), rfc3339(decoded.receiptCreationDate!))
+    }
+
+    ///Enabling online checks moves the evaluation to now, which is the point of the option: the same receipt must
+    ///then fail on the expired chain.
+    public func testReceiptSignedByNowExpiredCertificatesWithOnlineChecks() async throws {
+        let expiredCreator = try ReceiptCreator.createReceiptCreator(notBefore: ReceiptCreator.daysAgo(730), notAfter: ReceiptCreator.daysAgo(365))
+        let createdAt = ReceiptCreator.daysAgo(547)
+        let receipt = try expiredCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("ProductionSandbox", AppReceiptVerifierTests.BUNDLE_ID, rfc3339(createdAt)), signingTime: createdAt)
+
+        let verifier = AppReceiptVerifierTests.verifier(expiredCreator, environment: .sandbox, enableOnlineChecks: true)
+        await assertInvalid(.VERIFICATION_FAILURE, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+    }
+
+    ///Genuine App Store receipts carry no signed attributes and sign the encapsulated payload directly, unlike the
+    ///receipts most CMS tooling produces.
+    public func testReceiptWithoutSignedAttributes() async throws {
+        let receipt = try AppReceiptVerifierTests.receiptCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("ProductionSandbox", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE), signedAttributes: false)
+
+        let decoded = try await validReceipt(AppReceiptVerifierTests.verifier(environment: .sandbox).verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+        XCTAssertEqual(AppReceiptVerifierTests.BUNDLE_ID, decoded.bundleId)
+    }
+
+    ///Genuine App Store receipts encapsulate the payload in a constructed OCTET STRING, whose segments have to be
+    ///joined before the payload is either digested or decoded.
+    public func testReceiptWithSegmentedContent() async throws {
+        let receipt = try AppReceiptVerifierTests.receiptCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("ProductionSandbox", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE), segmentedContent: true)
+
+        let decoded = try await validReceipt(AppReceiptVerifierTests.verifier(environment: .sandbox).verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+        XCTAssertEqual(AppReceiptVerifierTests.BUNDLE_ID, decoded.bundleId)
+        XCTAssertEqual(2, decoded.inAppPurchases.count)
+    }
+
+    ///Xcode-generated receipts are not signed by the App Store, so they are decoded without any chain or signature check.
+    public func testXcodeReceiptDecoding() async throws {
+        let receipt = try AppReceiptVerifierTests.xcodeReceiptCreator.signReceipt(ReceiptCreator.doubleWrap(AppReceiptVerifierTests.receiptPayload("Xcode", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE)))
+
+        let decoded = try await validReceipt(AppReceiptVerifierTests.verifier(AppReceiptVerifierTests.xcodeReceiptCreator, environment: .xcode).verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+        XCTAssertEqual("Xcode", decoded.receiptType)
+        XCTAssertEqual(AppReceiptVerifierTests.BUNDLE_ID, decoded.bundleId)
+        XCTAssertEqual(AppReceiptVerifierTests.APP_VERSION, decoded.applicationVersion)
+        XCTAssertEqual(AppReceiptVerifierTests.RECEIPT_CREATION_DATE_VALUE, decoded.receiptCreationDate)
+        XCTAssertEqual(2, decoded.inAppPurchases.count)
+    }
+
+    ///Skipping the signature checks must not skip the app identity check.
+    public func testXcodeReceiptWithWrongBundleId() async throws {
+        let receipt = try AppReceiptVerifierTests.xcodeReceiptCreator.signReceipt(ReceiptCreator.doubleWrap(AppReceiptVerifierTests.receiptPayload("Xcode", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE)))
+
+        let verifier = AppReceiptVerifierTests.verifier(AppReceiptVerifierTests.xcodeReceiptCreator, environment: .xcode, bundleId: "com.example.other")
+        await assertInvalid(.INVALID_APP_IDENTIFIER, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+    }
+
+    ///Skipping the signature checks must not skip the environment check either.
+    public func testXcodeReceiptWithWrongEnvironment() async throws {
+        let receipt = try AppReceiptVerifierTests.xcodeReceiptCreator.signReceipt(ReceiptCreator.doubleWrap(AppReceiptVerifierTests.receiptPayload("Production", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE)))
+
+        let verifier = AppReceiptVerifierTests.verifier(AppReceiptVerifierTests.xcodeReceiptCreator, environment: .xcode)
+        await assertInvalid(.INVALID_ENVIRONMENT, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+    }
+
+    public func testVerifyAndExtractTransactionId() async throws {
+        let result = await AppReceiptVerifierTests.verifier(environment: .sandbox).verifyAndExtractTransactionId(encodedReceipt: encode(AppReceiptVerifierTests.sandboxReceipt))
+        switch result {
+        case .valid(let transactionId):
+            XCTAssertEqual("70000000000001", transactionId)
+        case .invalid(_):
+            XCTAssert(false)
+        }
+    }
+
+    ///Same output contract as ReceiptUtility: a verified receipt with no in-app purchases yields nil.
+    public func testVerifyAndExtractTransactionIdWithoutInAppPurchases() async throws {
+        let receipt = try AppReceiptVerifierTests.receiptCreator.signReceipt(ReceiptCreator.attributeSet()
+            .string(0, "ProductionSandbox")
+            .string(2, AppReceiptVerifierTests.BUNDLE_ID)
+            .date(12, AppReceiptVerifierTests.RECEIPT_CREATION_DATE)
+            .build())
+        let result = await AppReceiptVerifierTests.verifier(environment: .sandbox).verifyAndExtractTransactionId(encodedReceipt: encode(receipt))
+        switch result {
+        case .valid(let transactionId):
+            XCTAssertNil(transactionId)
+        case .invalid(_):
+            XCTAssert(false)
+        }
+    }
+
+    ///Unlike ReceiptUtility, extraction refuses a receipt that does not verify.
+    public func testVerifyAndExtractTransactionIdRejectsForeignReceipt() async throws {
+        let foreignCreator = try ReceiptCreator.createReceiptCreator()
+        let receipt = try foreignCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("ProductionSandbox", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE))
+
+        let result = await AppReceiptVerifierTests.verifier(environment: .sandbox).verifyAndExtractTransactionId(encodedReceipt: encode(receipt))
+        switch result {
+        case .valid(_):
+            XCTAssert(false)
+        case .invalid(let error):
+            XCTAssertEqual(VerificationError.VERIFICATION_FAILURE, error)
+        }
+    }
+
+    private static func verifier(_ creator: ReceiptCreator = receiptCreator, environment: AppStoreEnvironment, bundleId: String = BUNDLE_ID, enableOnlineChecks: Bool = false) -> AppReceiptVerifier {
+        return try! AppReceiptVerifier(rootCertificates: [creator.rootCertificate], bundleId: bundleId, environment: environment, enableOnlineChecks: enableOnlineChecks)
+    }
+
+    private static func receiptPayload(_ receiptType: String, _ bundleId: String, _ creationDate: String) -> [UInt8] {
+        return ReceiptCreator.attributeSet()
+            .string(0, receiptType)
+            .string(2, bundleId)
+            .string(3, APP_VERSION)
+            .raw(4, OPAQUE_VALUE)
+            .raw(5, SHA1_HASH)
+            .date(12, creationDate)
+            .date(18, ORIGINAL_PURCHASE_DATE)
+            .string(19, ORIGINAL_APP_VERSION)
+            .date(21, EXPIRATION_DATE)
+            .raw(9999, UNKNOWN_RECEIPT_ATTRIBUTE_VALUE)
+            .raw(17, consumablePurchase())
+            .raw(17, subscriptionPurchase())
+            .build()
+    }
+
+    private static func consumablePurchase() -> [UInt8] {
+        return ReceiptCreator.attributeSet()
+            .integer(1701, 1)
+            .string(1702, CONSUMABLE_PRODUCT_ID)
+            .string(1703, "70000000000001")
+            .date(1704, CONSUMABLE_PURCHASE_DATE)
+            .string(1705, "70000000000001")
+            .date(1706, CONSUMABLE_ORIGINAL_PURCHASE_DATE)
+            .date(1708, "")
+            .integer(1711, 42)
+            .date(1712, "")
+            .integer(1719, 0)
+            .raw(1799, UNKNOWN_IN_APP_ATTRIBUTE_VALUE)
+            .build()
+    }
+
+    private static func subscriptionPurchase() -> [UInt8] {
+        return ReceiptCreator.attributeSet()
+            .integer(1701, 1)
+            .string(1702, SUBSCRIPTION_PRODUCT_ID)
+            .string(1703, "70000000000002")
+            .date(1704, SUBSCRIPTION_PURCHASE_DATE)
+            .string(1705, "70000000000002")
+            .date(1706, SUBSCRIPTION_PURCHASE_DATE)
+            .date(1708, SUBSCRIPTION_EXPIRES_DATE)
+            .integer(1711, 12345)
+            .date(1712, SUBSCRIPTION_CANCELLATION_DATE)
+            .integer(1719, 1)
+            .build()
+    }
+
+    private func validReceipt(_ result: VerificationResult<AppReceipt>) throws -> AppReceipt {
+        switch result {
+        case .valid(let receipt):
+            return receipt
+        case .invalid(let error):
+            XCTFail("Expected a valid receipt, got \(error)")
+            throw XCTSkip("Expected a valid receipt, got \(error)")
+        }
+    }
+
+    private func assertInvalid<T>(_ expected: VerificationError, _ result: VerificationResult<T>) {
+        switch result {
+        case .valid(_):
+            XCTAssert(false)
+        case .invalid(let error):
+            XCTAssertEqual(expected, error)
+        }
+    }
+
+    private func encode(_ receipt: Data) -> String {
+        return receipt.base64EncodedString()
+    }
+
+    private func derEncodedUTF8String(_ value: String) -> Data {
+        var serializer = DER.Serializer()
+        try! serializer.serialize(ASN1UTF8String(value))
+        return Data(serializer.serializedBytes)
+    }
+
+    private func rfc3339(_ date: Date) -> String {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter.string(from: date)
+    }
+
+    private func indexOf(_ haystack: Data, _ needle: [UInt8]) throws -> Data.Index {
+        guard let range = haystack.range(of: Data(needle)) else {
+            throw XCTSkip("Expected bytes not found in the receipt")
+        }
+        return range.lowerBound
+    }
+}

--- a/Tests/AppStoreServerLibraryTests/AppReceiptVerifierTests.swift
+++ b/Tests/AppStoreServerLibraryTests/AppReceiptVerifierTests.swift
@@ -8,6 +8,7 @@ import SwiftASN1
 final class AppReceiptVerifierTests: XCTestCase {
 
     private static let BUNDLE_ID = "com.example"
+    private static let XCODE_BUNDLE_ID = "com.example.naturelab.backyardbirds.example"
     private static let APP_VERSION = "1.2.3"
     private static let ORIGINAL_APP_VERSION = "1.0"
     private static let OPAQUE_VALUE: [UInt8] = [1, 2, 3, 4, 5, 6, 7, 8]
@@ -241,6 +242,66 @@ final class AppReceiptVerifierTests: XCTestCase {
 
         let verifier = AppReceiptVerifierTests.verifier(AppReceiptVerifierTests.xcodeReceiptCreator, environment: .xcode)
         await assertInvalid(.INVALID_ENVIRONMENT, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+    }
+
+    ///The embedded certificates are attacker-supplied and are ordered into a chain before anything about the receipt
+    ///has been verified, so a receipt carrying more of them than a chain can hold is rejected rather than assembled.
+    public func testReceiptWithTooManyEmbeddedCertificates() async throws {
+        let receipt = try AppReceiptVerifierTests.receiptCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("ProductionSandbox", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE), paddingCertificates: 30)
+
+        let verifier = AppReceiptVerifierTests.verifier(environment: .sandbox)
+        await assertInvalid(.VERIFICATION_FAILURE, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+    }
+
+    ///A receipt Xcode actually produced, which unlike the synthetic ones above is BER with indefinite lengths,
+    ///segmented octet strings and a double-wrapped payload.
+    public func testXcodeGeneratedAppReceiptDecoding() async throws {
+        let verifier = try AppReceiptVerifier(rootCertificates: [TestingUtility.readBytes("resources/certs/testCA.der")], bundleId: AppReceiptVerifierTests.XCODE_BUNDLE_ID, environment: .xcode, enableOnlineChecks: false)
+
+        let receipt = try await validReceipt(await verifier.verifyAndDecodeAppReceipt(encodedReceipt: TestingUtility.readFile("resources/xcode/xcode-app-receipt-with-transaction")))
+
+        XCTAssertEqual("Xcode", receipt.receiptType)
+        XCTAssertEqual(AppReceiptVerifierTests.XCODE_BUNDLE_ID, receipt.bundleId)
+        XCTAssertEqual("1", receipt.applicationVersion)
+        XCTAssertEqual(Date(timeIntervalSince1970: 1697679940), receipt.receiptCreationDate)
+        XCTAssertEqual(1, receipt.inAppPurchases.count)
+        XCTAssertEqual("pass.premium", receipt.inAppPurchases[0].productId)
+        XCTAssertEqual("0", receipt.inAppPurchases[0].transactionId)
+    }
+
+    ///The output contract this shares with ReceiptUtility, checked against the same receipts.
+    public func testXcodeGeneratedAppReceiptTransactionIdExtraction() async throws {
+        let verifier = try AppReceiptVerifier(rootCertificates: [TestingUtility.readBytes("resources/certs/testCA.der")], bundleId: AppReceiptVerifierTests.XCODE_BUNDLE_ID, environment: .xcode, enableOnlineChecks: false)
+
+        switch await verifier.verifyAndExtractTransactionId(encodedReceipt: TestingUtility.readFile("resources/xcode/xcode-app-receipt-with-transaction")) {
+        case .valid(let transactionId):
+            XCTAssertEqual("0", transactionId)
+        case .invalid(let error):
+            XCTFail("Expected a valid receipt, got \(error)")
+        }
+        switch await verifier.verifyAndExtractTransactionId(encodedReceipt: TestingUtility.readFile("resources/xcode/xcode-app-receipt-empty")) {
+        case .valid(let transactionId):
+            XCTAssertNil(transactionId)
+        case .invalid(let error):
+            XCTFail("Expected a valid receipt, got \(error)")
+        }
+    }
+
+    ///As with an Xcode receipt, LocalTesting data is not signed by the App Store.
+    public func testLocalTestingReceiptDecoding() async throws {
+        let receipt = try AppReceiptVerifierTests.xcodeReceiptCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("LocalTesting", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE))
+
+        let decoded = try await validReceipt(AppReceiptVerifierTests.verifier(AppReceiptVerifierTests.xcodeReceiptCreator, environment: .localTesting).verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
+        XCTAssertEqual("LocalTesting", decoded.receiptType)
+        XCTAssertEqual(AppReceiptVerifierTests.BUNDLE_ID, decoded.bundleId)
+    }
+
+    ///Skipping the signature checks must not skip the app identity check.
+    public func testLocalTestingReceiptWithWrongBundleId() async throws {
+        let receipt = try AppReceiptVerifierTests.xcodeReceiptCreator.signReceipt(AppReceiptVerifierTests.receiptPayload("LocalTesting", AppReceiptVerifierTests.BUNDLE_ID, AppReceiptVerifierTests.RECEIPT_CREATION_DATE))
+
+        let verifier = AppReceiptVerifierTests.verifier(AppReceiptVerifierTests.xcodeReceiptCreator, environment: .localTesting, bundleId: "com.example.other")
+        await assertInvalid(.INVALID_APP_IDENTIFIER, await verifier.verifyAndDecodeAppReceipt(encodedReceipt: encode(receipt)))
     }
 
     public func testVerifyAndExtractTransactionId() async throws {

--- a/Tests/AppStoreServerLibraryTests/ReceiptCreator.swift
+++ b/Tests/AppStoreServerLibraryTests/ReceiptCreator.swift
@@ -79,7 +79,9 @@ public final class ReceiptCreator: Sendable {
     ///BouncyCastle does, rather than over the payload directly, as genuine App Store receipts do
     ///- Parameter segmentedContent: Whether to encapsulate the payload in a constructed, segmented OCTET STRING, the
     ///BER shape genuine App Store receipts arrive in, rather than a single primitive one
-    public func signReceipt(_ payload: [UInt8], embeddedCertificates: Int? = nil, signingTime: Date = Date(), signedAttributes: Bool = true, segmentedContent: Bool = false) throws -> Data {
+    ///- Parameter paddingCertificates: Unrelated certificates embedded on top of the chain, as a receipt bloated to
+    ///make chain assembly expensive carries
+    public func signReceipt(_ payload: [UInt8], embeddedCertificates: Int? = nil, signingTime: Date = Date(), signedAttributes: Bool = true, segmentedContent: Bool = false, paddingCertificates: Int = 0) throws -> Data {
         let signedAttributeBytes = signedAttributes ? try ReceiptCreator.signedAttributeSet(payload: payload, signingTime: signingTime) : nil
         let signature = try signingKey.signature(for: SHA256.hash(data: signedAttributeBytes ?? payload), padding: .insecurePKCS1v1_5)
 
@@ -108,6 +110,9 @@ public final class ReceiptCreator: Sendable {
                     coder.appendConstructedNode(identifier: ReceiptCreator.CONTEXT_TAG_0) { coder in
                         for certificate in chain.prefix(embeddedCertificates ?? chain.count) {
                             try! coder.serialize(certificate)
+                        }
+                        for index in 0..<paddingCertificates {
+                            try! coder.serialize(try! ReceiptCreator.paddingCertificate(index))
                         }
                     }
                     try coder.serializeSetOf([try signerInfo(signedAttributeBytes: signedAttributeBytes, signature: signature)])
@@ -256,6 +261,13 @@ public final class ReceiptCreator: Sendable {
 
     private static func rsaKey() throws -> _RSA.Signing.PrivateKey {
         return try _RSA.Signing.PrivateKey(keySize: .bits2048)
+    }
+
+    ///A self-signed certificate carrying the WWDR subject name, so that it is a candidate at every step of chain
+    ///assembly rather than being skipped after one comparison.
+    private static func paddingCertificate(_ index: Int) throws -> Certificate {
+        let key = try rsaKey()
+        return try certificate(subject: distinguishedName("Test WWDR CA"), subjectKey: key, issuer: distinguishedName("Test WWDR CA"), issuerKey: key, certificateAuthority: true, markerOid: nil, notBefore: daysAgo(3650), notAfter: inOneYear())
     }
 
     private static func distinguishedName(_ commonName: String) -> DistinguishedName {

--- a/Tests/AppStoreServerLibraryTests/ReceiptCreator.swift
+++ b/Tests/AppStoreServerLibraryTests/ReceiptCreator.swift
@@ -1,0 +1,301 @@
+// Copyright (c) 2026 Apple Inc. Licensed under MIT License.
+
+import Foundation
+import Crypto
+import _CryptoExtras
+import SwiftASN1
+import X509
+
+///Generates a throwaway "Apple-like" RSA PKI (root, WWDR intermediate, receipt signing leaf) and CMS-signs synthetic
+///legacy app receipts with it, so ``AppReceiptVerifier`` can be exercised without any real Apple key material or a
+///checked-in receipt.
+public final class ReceiptCreator: Sendable {
+
+    private static let WWDR_INTERMEDIATE_OID: ASN1ObjectIdentifier = [1, 2, 840, 113635, 100, 6, 2, 1]
+    private static let RECEIPT_SIGNER_OID: ASN1ObjectIdentifier = [1, 2, 840, 113635, 100, 6, 11, 1]
+
+    private static let SIGNED_DATA_OID: ASN1ObjectIdentifier = [1, 2, 840, 113549, 1, 7, 2]
+    private static let DATA_OID: ASN1ObjectIdentifier = [1, 2, 840, 113549, 1, 7, 1]
+    private static let CONTENT_TYPE_ATTRIBUTE_OID: ASN1ObjectIdentifier = [1, 2, 840, 113549, 1, 9, 3]
+    private static let MESSAGE_DIGEST_ATTRIBUTE_OID: ASN1ObjectIdentifier = [1, 2, 840, 113549, 1, 9, 4]
+    private static let SIGNING_TIME_ATTRIBUTE_OID: ASN1ObjectIdentifier = [1, 2, 840, 113549, 1, 9, 5]
+    private static let SHA256_OID: ASN1ObjectIdentifier = [2, 16, 840, 1, 101, 3, 4, 2, 1]
+    private static let RSA_ENCRYPTION_OID: ASN1ObjectIdentifier = [1, 2, 840, 113549, 1, 1, 1]
+
+    private static let CONTEXT_TAG_0 = ASN1Identifier(tagWithNumber: 0, tagClass: .contextSpecific)
+
+    private static let DAY: TimeInterval = 86400
+
+    ///Leaf first, then intermediate, then root; a self-signed creator holds one entry.
+    private let chain: [Certificate]
+    private let signingKey: _RSA.Signing.PrivateKey
+
+    private init(chain: [Certificate], signingKey: _RSA.Signing.PrivateKey) {
+        self.chain = chain
+        self.signingKey = signingKey
+    }
+
+    ///A chain carrying both Apple marker OIDs, with a validity window wide enough to cover any plausible receipt
+    ///creation date: the chain of a receipt is evaluated at the date the receipt was created, not now.
+    ///
+    ///- Parameter receiptSignerOid: Whether the leaf carries the receipt-signing marker OID
+    ///- Parameter wwdrIntermediateOid: Whether the intermediate carries the WWDR marker OID
+    ///- Parameter notBefore: The start of the validity window of every certificate in the chain
+    ///- Parameter notAfter: The end of the validity window of every certificate in the chain
+    public static func createReceiptCreator(receiptSignerOid: Bool = true, wwdrIntermediateOid: Bool = true, notBefore: Date = daysAgo(3650), notAfter: Date = inOneYear()) throws -> ReceiptCreator {
+        let rootKey = try rsaKey()
+        let intermediateKey = try rsaKey()
+        let leafKey = try rsaKey()
+        let rootName = distinguishedName("Test App Store Root CA")
+        let intermediateName = distinguishedName("Test WWDR CA")
+        let root = try certificate(subject: rootName, subjectKey: rootKey, issuer: rootName, issuerKey: rootKey, certificateAuthority: true, markerOid: nil, notBefore: notBefore, notAfter: notAfter)
+        let intermediate = try certificate(subject: intermediateName, subjectKey: intermediateKey, issuer: rootName, issuerKey: rootKey, certificateAuthority: true, markerOid: wwdrIntermediateOid ? WWDR_INTERMEDIATE_OID : nil, notBefore: notBefore, notAfter: notAfter)
+        let leaf = try certificate(subject: distinguishedName("Test Receipt Signing"), subjectKey: leafKey, issuer: intermediateName, issuerKey: intermediateKey, certificateAuthority: false, markerOid: receiptSignerOid ? RECEIPT_SIGNER_OID : nil, notBefore: notBefore, notAfter: notAfter)
+        return ReceiptCreator(chain: [leaf, intermediate, root], signingKey: leafKey)
+    }
+
+    ///A single self-signed certificate, as an Xcode-generated receipt carries; such a receipt is never chain verified.
+    public static func createSelfSignedReceiptCreator() throws -> ReceiptCreator {
+        let key = try rsaKey()
+        let name = distinguishedName("Test Xcode Receipt Signing")
+        let certificate = try certificate(subject: name, subjectKey: key, issuer: name, issuerKey: key, certificateAuthority: false, markerOid: RECEIPT_SIGNER_OID, notBefore: daysAgo(3650), notAfter: inOneYear())
+        return ReceiptCreator(chain: [certificate], signingKey: key)
+    }
+
+    ///The root of this chain, in the form the verifier's initializer accepts.
+    public var rootCertificate: Data {
+        var serializer = DER.Serializer()
+        try! serializer.serialize(chain[chain.count - 1])
+        return Data(serializer.serializedBytes)
+    }
+
+    ///CMS-signs `payload` as encapsulated content, embedding the chain.
+    ///
+    ///- Parameter embeddedCertificates: How many certificates of the chain, starting at the leaf, to embed in the container
+    ///- Parameter signingTime: The CMS signing time attribute, which a stricter verifier would require to fall inside
+    ///the signer certificate's validity window, so an old receipt signed by a since expired certificate needs its
+    ///original signing time
+    ///- Parameter signedAttributes: Whether to sign through a set of signed attributes, as a receipt produced by
+    ///BouncyCastle does, rather than over the payload directly, as genuine App Store receipts do
+    ///- Parameter segmentedContent: Whether to encapsulate the payload in a constructed, segmented OCTET STRING, the
+    ///BER shape genuine App Store receipts arrive in, rather than a single primitive one
+    public func signReceipt(_ payload: [UInt8], embeddedCertificates: Int? = nil, signingTime: Date = Date(), signedAttributes: Bool = true, segmentedContent: Bool = false) throws -> Data {
+        let signedAttributeBytes = signedAttributes ? try ReceiptCreator.signedAttributeSet(payload: payload, signingTime: signingTime) : nil
+        let signature = try signingKey.signature(for: SHA256.hash(data: signedAttributeBytes ?? payload), padding: .insecurePKCS1v1_5)
+
+        var serializer = DER.Serializer()
+        try serializer.appendConstructedNode(identifier: .sequence) { coder in
+            try coder.serialize(ReceiptCreator.SIGNED_DATA_OID)
+            try coder.appendConstructedNode(identifier: ReceiptCreator.CONTEXT_TAG_0) { coder in
+                try coder.appendConstructedNode(identifier: .sequence) { coder in
+                    try coder.serialize(1)
+                    try coder.serializeSetOf([ReceiptCreator.algorithmIdentifier(ReceiptCreator.SHA256_OID)])
+                    // encapContentInfo ::= SEQUENCE { eContentType OBJECT IDENTIFIER, eContent [0] EXPLICIT OCTET STRING }
+                    try coder.appendConstructedNode(identifier: .sequence) { coder in
+                        try coder.serialize(ReceiptCreator.DATA_OID)
+                        try coder.appendConstructedNode(identifier: ReceiptCreator.CONTEXT_TAG_0) { coder in
+                            if segmentedContent {
+                                let split = payload.count / 2
+                                try coder.appendConstructedNode(identifier: .octetString) { coder in
+                                    try coder.serialize(ASN1OctetString(contentBytes: payload[..<split]))
+                                    try coder.serialize(ASN1OctetString(contentBytes: payload[split...]))
+                                }
+                            } else {
+                                try coder.serialize(ASN1OctetString(contentBytes: payload[...]))
+                            }
+                        }
+                    }
+                    coder.appendConstructedNode(identifier: ReceiptCreator.CONTEXT_TAG_0) { coder in
+                        for certificate in chain.prefix(embeddedCertificates ?? chain.count) {
+                            try! coder.serialize(certificate)
+                        }
+                    }
+                    try coder.serializeSetOf([try signerInfo(signedAttributeBytes: signedAttributeBytes, signature: signature)])
+                }
+            }
+        }
+        return Data(serializer.serializedBytes)
+    }
+
+    ///The extra OCTET STRING wrapper Xcode-generated receipts put around the payload.
+    public static func doubleWrap(_ payload: [UInt8]) -> [UInt8] {
+        var serializer = DER.Serializer()
+        try! serializer.serialize(ASN1OctetString(contentBytes: payload[...]))
+        return serializer.serializedBytes
+    }
+
+    public static func attributeSet() -> AttributeSet {
+        return AttributeSet()
+    }
+
+    ///Builds a receipt attribute SET, the shape both the receipt payload and the value of an in-app purchase attribute
+    ///take. Each attribute is `SEQUENCE { type INTEGER, version INTEGER, value OCTET STRING }`.
+    public final class AttributeSet {
+        private var attributes: [DERBytes] = []
+
+        fileprivate init() {}
+
+        ///An attribute whose value is a DER UTF8String, e.g. the bundle identifier.
+        @discardableResult
+        public func string(_ type: Int64, _ value: String) -> AttributeSet {
+            var serializer = DER.Serializer()
+            try! serializer.serialize(ASN1UTF8String(value))
+            return raw(type, serializer.serializedBytes)
+        }
+
+        ///An attribute whose value is a DER IA5String holding an RFC 3339 date.
+        @discardableResult
+        public func date(_ type: Int64, _ value: String) -> AttributeSet {
+            var serializer = DER.Serializer()
+            try! serializer.serialize(try! ASN1IA5String(value))
+            return raw(type, serializer.serializedBytes)
+        }
+
+        ///An attribute whose value is a DER INTEGER, e.g. a purchase quantity.
+        @discardableResult
+        public func integer(_ type: Int64, _ value: Int64) -> AttributeSet {
+            var serializer = DER.Serializer()
+            try! serializer.serialize(value)
+            return raw(type, serializer.serializedBytes)
+        }
+
+        ///An attribute whose value bytes are used as-is, e.g. an opaque value or a nested SET.
+        @discardableResult
+        public func raw(_ type: Int64, _ value: [UInt8]) -> AttributeSet {
+            var serializer = DER.Serializer()
+            try! serializer.appendConstructedNode(identifier: .sequence) { coder in
+                try coder.serialize(type)
+                try coder.serialize(1)
+                try coder.serialize(ASN1OctetString(contentBytes: value[...]))
+            }
+            attributes.append(DERBytes(serializer.serializedBytes))
+            return self
+        }
+
+        public func build() -> [UInt8] {
+            var serializer = DER.Serializer()
+            try! serializer.serializeSetOf(attributes)
+            return serializer.serializedBytes
+        }
+    }
+
+    public static func inOneYear() -> Date {
+        return Date().addingTimeInterval(365 * DAY)
+    }
+
+    public static func daysAgo(_ days: Int) -> Date {
+        return Date().addingTimeInterval(-Double(days) * DAY)
+    }
+
+    ///`SignerInfo ::= SEQUENCE { version INTEGER, sid IssuerAndSerialNumber, digestAlgorithm AlgorithmIdentifier,`
+    ///`signedAttrs [0] IMPLICIT SignedAttributes OPTIONAL, signatureAlgorithm AlgorithmIdentifier, signature OCTET STRING }`
+    private func signerInfo(signedAttributeBytes: [UInt8]?, signature: _RSA.Signing.RSASignature) throws -> DERBytes {
+        let leaf = chain[0]
+        var serializer = DER.Serializer()
+        try serializer.appendConstructedNode(identifier: .sequence) { coder in
+            try coder.serialize(1)
+            try coder.appendConstructedNode(identifier: .sequence) { coder in
+                try coder.serialize(leaf.issuer)
+                try coder.serialize(leaf.serialNumber.bytes)
+            }
+            try coder.serialize(ReceiptCreator.algorithmIdentifier(ReceiptCreator.SHA256_OID))
+            if var implicitlyTagged = signedAttributeBytes {
+                // The same bytes that were signed, with the SET OF tag swapped back for the IMPLICIT [0] tag
+                implicitlyTagged[0] = 0xA0
+                coder.serializeRawBytes(implicitlyTagged)
+            }
+            try coder.serialize(ReceiptCreator.algorithmIdentifier(ReceiptCreator.RSA_ENCRYPTION_OID))
+            try coder.serialize(ASN1OctetString(contentBytes: ArraySlice(signature.rawRepresentation)))
+        }
+        return DERBytes(serializer.serializedBytes)
+    }
+
+    ///The signed attributes, serialized as the explicit SET OF the signature is computed over.
+    private static func signedAttributeSet(payload: [UInt8], signingTime: Date) throws -> [UInt8] {
+        let contentType = try attribute(CONTENT_TYPE_ATTRIBUTE_OID) { coder in
+            try coder.serialize(DATA_OID)
+        }
+        let messageDigest = try attribute(MESSAGE_DIGEST_ATTRIBUTE_OID) { coder in
+            try coder.serialize(ASN1OctetString(contentBytes: ArraySlice(Array(SHA256.hash(data: payload)))))
+        }
+        let signingTimeAttribute = try attribute(SIGNING_TIME_ATTRIBUTE_OID) { coder in
+            try coder.serialize(utcTime(signingTime))
+        }
+        var serializer = DER.Serializer()
+        try serializer.serializeSetOf([contentType, messageDigest, signingTimeAttribute])
+        return serializer.serializedBytes
+    }
+
+    ///`Attribute ::= SEQUENCE { attrType OBJECT IDENTIFIER, attrValues SET OF ANY }`
+    private static func attribute(_ oid: ASN1ObjectIdentifier, _ value: (inout DER.Serializer) throws -> Void) throws -> DERBytes {
+        var serializer = DER.Serializer()
+        try serializer.appendConstructedNode(identifier: .sequence) { coder in
+            try coder.serialize(oid)
+            try coder.appendConstructedNode(identifier: .set) { coder in
+                try value(&coder)
+            }
+        }
+        return DERBytes(serializer.serializedBytes)
+    }
+
+    private static func algorithmIdentifier(_ oid: ASN1ObjectIdentifier) -> DERBytes {
+        var serializer = DER.Serializer()
+        try! serializer.appendConstructedNode(identifier: .sequence) { coder in
+            try coder.serialize(oid)
+            try coder.serialize(ASN1Null())
+        }
+        return DERBytes(serializer.serializedBytes)
+    }
+
+    private static func utcTime(_ date: Date) throws -> UTCTime {
+        var calendar = Calendar(identifier: .gregorian)
+        calendar.timeZone = TimeZone(identifier: "UTC")!
+        let components = calendar.dateComponents([.year, .month, .day, .hour, .minute, .second], from: date)
+        return try UTCTime(year: components.year!, month: components.month!, day: components.day!, hours: components.hour!, minutes: components.minute!, seconds: components.second!)
+    }
+
+    private static func rsaKey() throws -> _RSA.Signing.PrivateKey {
+        return try _RSA.Signing.PrivateKey(keySize: .bits2048)
+    }
+
+    private static func distinguishedName(_ commonName: String) -> DistinguishedName {
+        return try! DistinguishedName {
+            CommonName(commonName)
+        }
+    }
+
+    private static func certificate(subject: DistinguishedName, subjectKey: _RSA.Signing.PrivateKey, issuer: DistinguishedName, issuerKey: _RSA.Signing.PrivateKey, certificateAuthority: Bool, markerOid: ASN1ObjectIdentifier?, notBefore: Date, notAfter: Date) throws -> Certificate {
+        var extensions = [
+            try Certificate.Extension(certificateAuthority ? BasicConstraints.isCertificateAuthority(maxPathLength: nil) : BasicConstraints.notCertificateAuthority, critical: true)
+        ]
+        if let markerOid {
+            // The Apple marker extensions are non-critical and carry a DER NULL as their value
+            extensions.append(Certificate.Extension(oid: markerOid, critical: false, value: [0x05, 0x00]))
+        }
+        return try Certificate(
+            version: .v3,
+            serialNumber: Certificate.SerialNumber(),
+            publicKey: Certificate.PublicKey(subjectKey.publicKey),
+            notValidBefore: notBefore,
+            notValidAfter: notAfter,
+            issuer: issuer,
+            subject: subject,
+            signatureAlgorithm: .sha256WithRSAEncryption,
+            extensions: try Certificate.Extensions(extensions),
+            issuerPrivateKey: Certificate.PrivateKey(issuerKey)
+        )
+    }
+}
+
+///Already-encoded DER, so pieces built separately can be nested and sorted into a SET OF.
+struct DERBytes: DERSerializable {
+    private let bytes: [UInt8]
+
+    init(_ bytes: [UInt8]) {
+        self.bytes = bytes
+    }
+
+    func serialize(into coder: inout DER.Serializer) throws {
+        coder.serializeRawBytes(bytes)
+    }
+}


### PR DESCRIPTION
Resolves #132. Companion to apple/app-store-server-library-java#268 — the same design, ported to this library's idiom; the same shape is also open as apple/app-store-server-library-python#208 and apple/app-store-server-library-node#427.

Adds `AppReceiptVerifier`, the validating counterpart to `ReceiptUtility`: it verifies the PKCS#7 app receipt's certificate chain and signature, then decodes the receipt and its in-app purchase attributes. For apps that still support iOS 14 and earlier, where StoreKit 2 isn't available, the app receipt is the only purchase artifact there is — and today the library extracts a transaction ID from it without checking that the App Store ever signed it.

Design notes:

- **Maximum reuse of the existing trust code.** The embedded certificates are ordered leaf → intermediate → root and handed to the existing `ChainVerifier`, whose `AppStoreOIDPolicy` already enforces the chain length and both Apple marker OIDs (WWDR intermediate 1.2.840.113635.100.6.2.1, receipt-signing leaf 1.2.840.113635.100.6.11.1), against the same caller-supplied Apple root certificates `SignedDataVerifier` takes. No new trust logic, and OCSP network failures map to `RETRYABLE_VERIFICATION_FAILURE` exactly as the JWS path does.
- **Chain validity is evaluated at the receipt's creation date** (via `ChainVerifier`'s existing `validationTime` parameter), so old receipts survive certificate rotations — in line with [Apple's Dec 2022 signing-certificate notice](https://developer.apple.com/news/?id=ytb7qj0x). `enableOnlineChecks` moves evaluation to the current date and enables revocation checking, matching `SignedDataVerifier`'s semantics.
- **The container is parsed with BER, not DER**, because Xcode receipts use indefinite lengths and segmented OCTET STRINGs (App Store receipts are definite-length DER; the parser takes both) — and the signature is verified over the signed attributes when present, or the payload directly otherwise, which is how genuine receipts sign. Both paths are tested.
- **No API surface beyond the new types.** Same `VerificationResult` shape as `SignedDataVerifier`; no new `VerificationError` cases. In the Xcode and LocalTesting environments the signature checks are skipped but the bundle id and environment are still validated, mirroring `SignedDataVerifier`.
- **Models** `AppReceipt` and `InAppPurchaseReceipt` are `Hashable, Sendable` structs with `Date?` fields, matching the existing model style. Attribute types the library doesn't model are preserved as raw bytes, so fields Apple adds later stay reachable without a library update.
- **`verifyAndExtractTransactionId`** returns a transaction id only after verification, and `.valid(nil)` means verified with no in-app purchases. For a receipt carrying several purchases it deliberately differs from `ReceiptUtility`: this returns the first purchase's transaction id, where `ReceiptUtility` keeps overwriting and so yields the last purchase's original transaction id. Deterministic seemed better than bug-compatible; say the word if you'd rather it match exactly. The doc comment states the difference. `ReceiptUtility`'s doc comment now cross-references it (doc-only touch there).
- **No new dependencies.** The library target is unchanged; the test target gains `_CryptoExtras` from the already-declared swift-crypto package, solely to generate throwaway RSA test keys.

**Adversarial review pass.** After opening this, I had the branch reviewed adversarially (independent per-language passes, each running its own probes). No verification bypass was found in any language — signature-to-payload binding, chain-to-signing-key binding, the digest allowlist, the RFC 5652 re-tag and trailing-byte rejection were each positively verified rather than assumed. What the review did find, and what a later commit here fixes, was denial of service: work reachable *before* anything about a receipt has been verified, needing no Apple key material. Ordering the embedded certificates into a chain compared them for equality, so a 227 KB receipt embedding 800 certificates measured at 63 seconds of one core. Those bounds sit before the expensive step. A later pass then put a test behind each pre-verification bound and each receipt shape the verifier claims to handle — tests that fail when their bound is removed or widened by one, found by running mutations over the previous suite rather than by assuming the earlier tests covered them.

Tests generate a throwaway in-memory PKI (`ReceiptCreator`) and CMS-sign synthetic receipts — no real receipts or Apple key material. `AppReceiptVerifierTests` holds 56 tests covering decoding, tampering, foreign roots, missing marker OIDs, chain length, trailing bytes, expired-chain-at-creation-date behavior (with and without online checks), Xcode receipts, segmented content, receipts without signed attributes, the pre-verification bounds, an OCSP responder in the chain, and the extraction contract. The full suite passes (211 tests). The repository's existing Xcode receipt fixtures are now decoded by the new code too, which exercises the real BER shape rather than a synthetic one.

The same design is shipped and cross-verified in all four library languages in [apple-purchase-receipt-verifier](https://github.com/emindeniz99/apple-purchase-receipt-verifier) (MIT), against a shared fixture suite — this PR is that implementation rewritten in this library's idiom, reusing its existing trust code instead of carrying its own.

Happy to adjust naming or shape to whatever fits the library best.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>


